### PR TITLE
Improve readability of RFC 2119 keywords

### DIFF
--- a/technical-reports/format/index.html
+++ b/technical-reports/format/index.html
@@ -28,10 +28,8 @@
     </script>
     <style>
       .rfc2119 {
-        text-transform: lowercase;
-        font-variant: small-caps;
         font-style: normal;
-        font-size: 1.12em;
+        font-size: 0.875em;
       }
     </style>
   </head>

--- a/technical-reports/format/index.html
+++ b/technical-reports/format/index.html
@@ -31,7 +31,7 @@
         text-transform: lowercase;
         font-variant: small-caps;
         font-style: normal;
-        font-size: 1.125em;
+        font-size: 1.12em;
       }
     </style>
   </head>

--- a/technical-reports/format/index.html
+++ b/technical-reports/format/index.html
@@ -26,6 +26,14 @@
         tocIntroductory: true,
       };
     </script>
+    <style>
+      .rfc2119 {
+        text-transform: lowercase;
+        font-variant: small-caps;
+        font-style: normal;
+        font-size: 1.125em;
+      }
+    </style>
   </head>
   <body>
     <p class="copyright remove"></p>


### PR DESCRIPTION
As per https://w3c.github.io/manual-of-style/#RFC but with slightly bumped up text, aligning small caps with surrounding text's x-height:

![Screen Shot 2021-09-13 at 1 45 52 PM](https://user-images.githubusercontent.com/85783/133154057-6770fea4-486d-47f8-a65e-2d2df506f0f5.png)
![Screen Shot 2021-09-13 at 1 46 18 PM](https://user-images.githubusercontent.com/85783/133154061-f3c79355-e0a7-4e8a-9d0e-c038bed59283.png)
