### PR TITLE
Setup and editing instructions for technical reports

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,7 @@
 {
-  "recommendations": ["esbenp.prettier-vscode", "editorconfig.editorconfig"]
+  "recommendations": [
+    "esbenp.prettier-vscode",
+    "editorconfig.editorconfig",
+    "huntertran.auto-markdown-toc"
+  ]
 }

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ We believe that a common way to share design tokens will unlock efficiency oppor
 
 [Read the charter in full](https://github.com/design-tokens/community-group/blob/main/CHARTER.md).
 
+[View the latest technical reports](https://design-tokens.github.io/community-group/)
+
 ## Roadmap
 
 The DTCG was founded in June 2019. By the end of 2019, our aim is to have a standard working across at least 3 design or prototyping tools.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ We believe that a common way to share design tokens will unlock efficiency oppor
 
 [Read the charter in full](https://github.com/design-tokens/community-group/blob/main/CHARTER.md).
 
-[View the latest technical reports](https://design-tokens.github.io/community-group/) ([Instructions for editing technical reports](./technical-reports/README.md)).
+[Browse the latest technical reports](https://design-tokens.github.io/community-group/) ([Instructions for editing technical reports](./technical-reports/README.md)).
 
 ## Roadmap
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ We believe that a common way to share design tokens will unlock efficiency oppor
 
 [Read the charter in full](https://github.com/design-tokens/community-group/blob/main/CHARTER.md).
 
-[View the latest technical reports](https://design-tokens.github.io/community-group/)
+[View the latest technical reports](https://design-tokens.github.io/community-group/) ([Instructions for editing technical reports](./technical-reports/README.md)).
 
 ## Roadmap
 

--- a/technical-reports/README.md
+++ b/technical-reports/README.md
@@ -18,14 +18,13 @@ In order to preview edits locally, you will need the following installed on your
 
 - [Node.js](https://nodejs.org/en/) >= 16.8
   - If you use [`nvm`](https://github.com/nvm-sh/nvm), you can run `nvm install` to install and use the recommended version of Node.
-- [Yarn](https://yarnpkg.com/)
 
 ## Initial setup
 
 After cloning this repo, you need to install the dependencies:
 
 ```
-yarn
+npm install
 ```
 
 This step does not need to be repeated unless the dependencies are changed.
@@ -35,7 +34,7 @@ This step does not need to be repeated unless the dependencies are changed.
 To see live previews of local edits to the technical reports run:
 
 ```
-yarn dev
+npm run dev
 ```
 
 ## Editing
@@ -53,6 +52,6 @@ To making editing our format specification more convenient and to reduce the lik
 
 ## Deployments
 
-Any changes to the source files in this directory that get merged into `main` are automatically deployed to [`https://design-tokens.github.io/community-group/`](https://design-tokens.github.io/community-group/) via the [`technical-reports` Github Action](../.github/workflows/technical-reports.yml). They are hosted using Github Pages and the build output can be found in the [`gh-pages` branch](https://github.com/design-tokens/community-group/tree/gh-pages).
+Any changes to the source files in this directory that get merged into `main` are automatically deployed to [`https://design-tokens.github.io/community-group/`](https://design-tokens.github.io/community-group/) via the [`technical-reports` GitHub Action](../.github/workflows/technical-reports.yml). They are hosted using GitHub Pages and the build output can be found in the [`gh-pages` branch](https://github.com/design-tokens/community-group/tree/gh-pages).
 
 Additionally, we use Netlify to generate preview deploys for PRs. Netlify will post a comment to the PR with the URL of the preview once it is ready.

--- a/technical-reports/README.md
+++ b/technical-reports/README.md
@@ -1,0 +1,58 @@
+# DTCG Technical Reports
+
+This directory contains the source code for the [Design Token Community Group's (DTCG) technical reports](https://design-tokens.github.io/community-group/).
+
+<!-- TOC depthfrom:2 -->
+
+- [Pre-requisites](#pre-requisites)
+- [Initial setup](#initial-setup)
+- [Local previews](#local-previews)
+- [Editing](#editing)
+- [Deployments](#deployments)
+
+<!-- /TOC -->
+
+## Pre-requisites
+
+In order to preview edits locally, you will need the following installed on your machine:
+
+- [Node.js](https://nodejs.org/en/) >= 16.8
+  - If you use [`nvm`](https://github.com/nvm-sh/nvm), you can run `nvm install` to install and use the recommended version of Node.
+- [Yarn](https://yarnpkg.com/)
+
+## Initial setup
+
+After cloning this repo, you need to install the dependencies:
+
+```
+yarn
+```
+
+This step does not need to be repeated unless the dependencies are changed.
+
+## Local previews
+
+To see live previews of local edits to the technical reports run:
+
+```
+yarn dev
+```
+
+## Editing
+
+We use the [W3C's ReSpec tool](https://respec.org/docs/) to generate our technical reports. Although knowledge of HTML and Markdown is sufficient for simple edits, we recommend that authors familiarise themselves with ReSpec's features.
+
+To making editing our format specification more convenient and to reduce the likelihood of merge conflicts, we have split out the main chapters into separate Markdown files. The `format/index.html` then includes them all using [ReSpec's `data-include` feature](https://respec.org/docs/#data-include). For example:
+
+```html
+<section
+  data-include="./file-format.md"
+  data-include-format="markdown"
+></section>
+```
+
+## Deployments
+
+Any changes to the source files in this directory that get merged into `main` are automatically deployed to [`https://design-tokens.github.io/community-group/`](https://design-tokens.github.io/community-group/) via the [`technical-reports` Github Action](../.github/workflows/technical-reports.yml). They are hosted using Github Pages and the build output can be found in the [`gh-pages` branch](https://github.com/design-tokens/community-group/tree/gh-pages).
+
+Additionally, we use Netlify to generate preview deploys for PRs. Netlify will post a comment to the PR with the URL of the preview once it is ready.


### PR DESCRIPTION
This PR:

* Adds a `README` in the technical reports directory with instructions on how to preview and edit them.
* Adds the "Auto Markdown TOC" VSCode extension to this repo's recommended extensions as I used it to generate the table of contents in the `README`.
* Adds a link to our deployed technical reports in the main `README`