### PR TITLE
Update composite types chapter to reflect decision made on issue #63

### DIFF
--- a/technical-reports/format/composite-types.md
+++ b/technical-reports/format/composite-types.md
@@ -95,7 +95,34 @@ Represents a border style. The type property must be set to the string “border
 
 - `color`: The color of the border. The value of this property must be a valid [color value](#color) or a reference to a color token.
 - `width`: The width or thickness of the border. The value of this property must be a valid [dimension value](#dimension) or a reference to a dimension token.
-- `style`: The border's style, for example "solid" or "dashed". The value of this property must be a valid JSON string or a reference to another string token.
+- `style`: The border's style, for example "solid" or "dashed". The value of this property must be a valid JSON string or a reference to a string token.
+
+<aside class="example" title="Border composite token examples">
+
+```json
+{
+  "border": {
+    "heavy": {
+      "type": "border",
+      "value": {
+        "color": "#36363600",
+        "width": "3px",
+        "style": "solid"
+      }
+    },
+    "focusring": {
+      "type": "border",
+      "value": {
+        "color": "{color.focusring}",
+        "width": "1px",
+        "style": "dashed"
+      }
+    }
+  }
+}
+```
+
+</aside>
 
 # Transition
 
@@ -115,6 +142,43 @@ Represents a shadow style. The type property must be set to the string “shadow
 
 TO-DO
 
-# Text style
+# Typography
 
-TO-DO
+Represents a typographic style. The type property must be set to the string “typography”. The value must be an object with the following properties:
+
+- `fontName`: The typography's font. The value of this property must be a valid [font name](#font-name) or a reference to a font name token.
+- `fontSize`: The size of the typography. The value of this property must be a valid [dimension value](#dimension) or a reference to a dimension token.
+- `fontWeight`: The weight of the typography. The value of this property must be a valid JSON string or a reference to a string token.
+- `letterSpacing`: The horizontal spacing between characters. The value of this property must be a valid [dimension value](#dimension) or a reference to a dimension token.
+- `lineHeight`: The vertical spacing between lines of typography. The value of this property must be a valid JSON string or a reference to a string token.
+
+<aside class="example" title="Typography composite token examples">
+
+```json
+{
+  "type styles": {
+    "heading-level-1": {
+      "type": "typography",
+      "value": {
+        "fontName": "Roboto",
+        "fontSize": "42px",
+        "fontWeight": "700",
+        "letterSpacing": "0.1px",
+        "lineHeight": "1.2"
+      }
+    },
+    "microcopy": {
+      "type": "typography",
+      "value": {
+        "fontName": "{font.serif}",
+        "fontSize": "{font.size.smallest}",
+        "fontWeight": "{font.weight.normal}",
+        "letterSpacing": "0px",
+        "lineHeight": "1"
+      }
+    }
+  }
+}
+```
+
+</aside>

--- a/technical-reports/format/composite-types.md
+++ b/technical-reports/format/composite-types.md
@@ -6,13 +6,14 @@ Every shadow style has the exact same parts (color, X & Y offsets, etc.), but th
 
 Specifically, a composite type has the following characteristics:
 
-- Its value is an object containing sub-values.
-- Each sub-value has a pre-defined name and type.
+- Its value is an object or array containing sub-values.
+- For object values, each sub-value has a pre-defined name and type.
+- For array values, all elements of the array are sub-values that have the same pre-defined type.
 - Sub-values may be explicit values (e.g. `"#ff0000"`) or references to other design tokens that have sub-value's type (e.g. `"{some.other.token}"`).
 
 A design token whose type happens to be a composite type is sometimes also called a composite (design) token. Besides their type, there is nothing special about composite tokens. They can have all the other additional properties like [description](#description) or [extensions](#extensions). They can also be referenced by other design tokens.
 
-<aside class="example" title="Composite token exmple">
+<aside class="example" title="Composite token example">
 
 ```json
 {
@@ -138,9 +139,107 @@ Represents a shadow style. The type property must be set to the string “shadow
 - `blur`: The blur radius that is applied to the shadow. The value of this property must be a valid [dimension value](#dimension) or a reference to a dimension token.
 - `spread`: The amount by which to expand or contract the shadow. The value of this property must be a valid [dimension value](#dimension) or a reference to a dimension token.
 
+# Gradient Stop
+
+Represents an individual stop on a color gradient. In practice, this type is unlikely to be useful by itself, but it is required by the [gradient type](#gradient). The value must be an object with the following properties:
+
+- `color`: The color value at the stop's position on the gradient. The value of this property must be a valid [color value](#color) or a reference to a color token.
+- `position`: The position of the stop along the gradient's axis. The value of this property must be a valid number value or reference to a number token. The number values must be in the range [0, 1], where 0 represents the start position of the gradient's axis and 1 the end position. If a number value outside of that range is given, it MUST be considered as if it were clamped to the range [0, 1]. For example, a value of 42 should be treated as if it were 1, i.e. the end position of the gradient axis. Similarly, a value of -99 should be treated as if it were 0, i.e. the start position of the gradient axis.
+
 # Gradient
 
-TO-DO
+Represents a color gradient. The value must be an array of [gradient stops](#gradient-stop). If there are no stops at the very beginning or end of the gradient axis (i.e. with `position` 0 or 1, respectively), then the color from the stop closest to each end should be extended to that end of the axis.
+
+<aside class="example" title="Gradient token example">
+
+```json
+{
+  "blue-to-red": {
+    "type": "gradient",
+    "value": [
+      {
+        "color": "#0000ff",
+        "pos": 0
+      },
+      {
+        "color": "#ff0000",
+        "pos": 1
+      }
+    ]
+  }
+}
+```
+
+Describes a gradient that goes from blue to red:
+
+<div style="height: 2rem; background: linear-gradient(90deg, #0000ff, #ff0000);"></div>
+
+</aside>
+
+<aside class="example" title="Gradient token with omitted start stop example">
+
+```json
+{
+  "mostly-yellow": {
+    "type": "gradient",
+    "value": [
+      {
+        "color": "#ffff00",
+        "pos": 0.666
+      },
+      {
+        "color": "#ff0000",
+        "pos": 1
+      }
+    ]
+  }
+}
+```
+
+Describes a gradient that is solid yellow for the first 2/3 and then fades to red:
+
+<div style="height: 2rem; background: linear-gradient(90deg, #ffff00 66.6%, #ff0000);"></div>
+
+</aside>
+
+<aside class="example" title="Gradient token using references example">
+
+```json
+{
+  "brand-primary": {
+    "type": "color",
+    "value": "#99ff66"
+  },
+
+  "position-end": {
+    "value": 1
+  },
+
+  "brand-in-the-middle": {
+    "type": "gradient",
+    "value": [
+      {
+        "color": "#000000",
+        "pos": 0
+      },
+      {
+        "color": "{brand-primary}",
+        "pos": 0.5
+      },
+      {
+        "color": "#000000",
+        "pos": "{position-end}"
+      }
+    ]
+  }
+}
+```
+
+Describes a color token called "brand-primary", which is referenced as the mid-point of a gradient is black at either end.
+
+<div style="height: 2rem; background: linear-gradient(90deg, #000000, #99ff66, #000000);"></div>
+
+</aside>
 
 # Typography
 

--- a/technical-reports/format/composite-types.md
+++ b/technical-reports/format/composite-types.md
@@ -19,8 +19,8 @@ A design token whose type happens to be a composite type is sometimes also calle
     "type": "shadow",
     "value": {
       "color": "#00000088",
-      "x": "0.5rem",
-      "y": "0.5rem",
+      "offset-x": "0.5rem",
+      "offset-y": "0.5rem",
       "blur": "1.5rem",
       "spread": "0rem"
     }
@@ -54,8 +54,8 @@ A design token whose type happens to be a composite type is sometimes also calle
       "description": "A composite token where some sub-values are references to tokens that have the correct type and others are explicit values",
       "value": {
         "color": "{color.shadow-050}",
-        "x": "{space.small}",
-        "y": "{space.small}",
+        "offset-x": "{space.small}",
+        "offset-y": "{space.small}",
         "blur": "1.5rem",
         "spread": "0rem"
       }
@@ -240,10 +240,29 @@ TO-DO
 Represents a shadow style. The type property must be set to the string “shadow”. The value must be an object with the following properties:
 
 - `color`: The color of the shadow. The value of this property must be a valid [color value](#color) or a reference to a color token.
-- `x`: The horizontal offset that shadow has from the element it is applied to. The value of this property must be a valid [dimension value](#dimension) or a reference to a dimension token.
-- `y`: The vertical offset that shadow has from the element it is applied to. The value of this property must be a valid [dimension value](#dimension) or a reference to a dimension token.
+- `offset-x`: The horizontal offset that shadow has from the element it is applied to. The value of this property must be a valid [dimension value](#dimension) or a reference to a dimension token.
+- `offset-y`: The vertical offset that shadow has from the element it is applied to. The value of this property must be a valid [dimension value](#dimension) or a reference to a dimension token.
 - `blur`: The blur radius that is applied to the shadow. The value of this property must be a valid [dimension value](#dimension) or a reference to a dimension token.
 - `spread`: The amount by which to expand or contract the shadow. The value of this property must be a valid [dimension value](#dimension) or a reference to a dimension token.
+
+<aside class="example" title="Shadow token example">
+
+```json
+{
+  "shadow-token": {
+    "type": "shadow",
+    "value": {
+      "color": "#00000088",
+      "offset-x": "0.5rem",
+      "offset-y": "0.5rem",
+      "blur": "1.5rem",
+      "spread": "0rem"
+    }
+  }
+}
+```
+
+</aside>
 
 ## Gradient
 

--- a/technical-reports/format/composite-types.md
+++ b/technical-reports/format/composite-types.md
@@ -411,7 +411,7 @@ Describes a color token called "brand-primary", which is referenced as the mid-p
 
 Represents a typographic style. The type property must be set to the string “typography”. The value must be an object with the following properties:
 
-- `fontFamily`: The typography's font. The value of this property must be a valid [fontFamily](#font-family) or a reference to a font name token.
+- `fontFamily`: The typography's font. The value of this property must be a valid [fontFamily value](#font-family) or a reference to a font family token.
 - `fontSize`: The size of the typography. The value of this property must be a valid [dimension value](#dimension) or a reference to a dimension token.
 - `fontWeight`: The weight of the typography. The value of this property must be a valid [font weight](#font-weight) or a reference to a font weight token.
 - `letterSpacing`: The horizontal spacing between characters. The value of this property must be a valid [dimension value](#dimension) or a reference to a dimension token.

--- a/technical-reports/format/composite-types.md
+++ b/technical-reports/format/composite-types.md
@@ -95,6 +95,10 @@ Represents the style applied to lines or borders. The `type` property must be se
 - a string value as defined in the corresponding section below, or
 - an object value as defined in the corresponding section below
 
+<div class="issue" data-number="98" title="Stroke style type feedback">
+  Is the current specification for stroke styles fit for purpose? Does it need more sub-values (e.g. equivalents to SVG's `stroke-linejoin`, `stroke-miterlimit` and `stroke-dashoffset` attributes)? 
+</div>
+
 ### String value
 
 String stroke style values MUST be set to one of the following, pre-defined values:
@@ -231,9 +235,40 @@ Represents a border style. The type property must be set to the string “border
 
 </aside>
 
+<div class="issue" data-number="99" title="Border type feedback">
+  Is the current specification for borders fit for purpose? Does it need more sub-values to account for features like outset, border images, multiple borders, etc. that some platforms an design tools have?
+</div>
+
 ## Transition
 
-TO-DO
+Represents a animated transition between two states. The type property must be set to the string "transition". The value must be an object with the following properties:
+
+- `duration`: The duration of the transition. The value of this property must be a valid [duration](#duration) value or a reference to a duration token.
+- `delay`: The time to wait before the transition begins. The value of this property must be a valid [duration](#duration) value or a reference to a duration token.
+- `timing-function`: The color of the shadow. The value of this property must be a valid [cubic bézier](#cubic-bezier) value or a reference to a cubic bézier token.
+
+<aside class="example" title="Transition composite token examples">
+
+```json
+{
+  "transition": {
+    "emphasis": {
+      "type": "transition",
+      "value": {
+        "duration": "200ms",
+        "delay": "0ms",
+        "timing-function": [0.5, 0, 1, 1]
+      }
+    }
+  }
+}
+```
+
+</aside>
+
+<div class="issue" data-number="103" title="Transition type feedback">
+  Is the current specification for transitions fit for purpose? Are these transitions parameters by themselves useful considering that they don't let you specify what aspect of a UI is being transitioned and what the start and end states are?
+</div>
 
 ## Shadow
 
@@ -263,6 +298,10 @@ Represents a shadow style. The type property must be set to the string “shadow
 ```
 
 </aside>
+
+<div class="issue" data-number="100" title="Shadow type feedback">
+  Is the current specification for shadows fit for purpose? Does it need to support multiple shadows, as some tools and platforms do? 
+</div>
 
 ## Gradient
 
@@ -364,6 +403,10 @@ Describes a color token called "brand-primary", which is referenced as the mid-p
 
 </aside>
 
+<div class="issue" data-number="101" title="Gradient type feedback">
+  Is the current specification for gradients fit for purpose? Does it need to also specify the type of gradient (.e.g linear, radial, concial, etc.)?
+</div>
+
 ## Typography
 
 Represents a typographic style. The type property must be set to the string “typography”. The value must be an object with the following properties:
@@ -404,3 +447,9 @@ Represents a typographic style. The type property must be set to the string “t
 ```
 
 </aside>
+
+<div class="issue" data-number="102" title="Typography type feedback">
+
+Is the current specification for typography styles fit for purpose? [Should the `lineHeight` sub-value use a number value, dimension or a new line-height type](https://github.com/design-tokens/community-group/pull/86#discussion_r768137006)?
+
+</div>

--- a/technical-reports/format/composite-types.md
+++ b/technical-reports/format/composite-types.md
@@ -411,7 +411,7 @@ Describes a color token called "brand-primary", which is referenced as the mid-p
 
 Represents a typographic style. The type property must be set to the string “typography”. The value must be an object with the following properties:
 
-- `fontName`: The typography's font. The value of this property must be a valid [font name](#font-name) or a reference to a font name token.
+- `fontFamily`: The typography's font. The value of this property must be a valid [fontFamily](#font-family) or a reference to a font name token.
 - `fontSize`: The size of the typography. The value of this property must be a valid [dimension value](#dimension) or a reference to a dimension token.
 - `fontWeight`: The weight of the typography. The value of this property must be a valid [font weight](#font-weight) or a reference to a font weight token.
 - `letterSpacing`: The horizontal spacing between characters. The value of this property must be a valid [dimension value](#dimension) or a reference to a dimension token.
@@ -425,7 +425,7 @@ Represents a typographic style. The type property must be set to the string “t
     "heading-level-1": {
       "type": "typography",
       "value": {
-        "fontName": "Roboto",
+        "fontFamily": "Roboto",
         "fontSize": "42px",
         "fontWeight": "700",
         "letterSpacing": "0.1px",
@@ -435,7 +435,7 @@ Represents a typographic style. The type property must be set to the string “t
     "microcopy": {
       "type": "typography",
       "value": {
-        "fontName": "{font.serif}",
+        "fontFamily": "{font.serif}",
         "fontSize": "{font.size.smallest}",
         "fontWeight": "{font.weight.normal}",
         "letterSpacing": "0px",

--- a/technical-reports/format/composite-types.md
+++ b/technical-reports/format/composite-types.md
@@ -2,7 +2,7 @@
 
 The types defined in the previous chapters such as color and dimension all have singular values. For example, the value of a color token is _one_ color. However, there are other aspects of UI designs that are a combination of multiple values. For instance, a shadow style is a combination of a color, X & Y offsets, a blur radius and a spread radius.
 
-Every shadow style has the exact same parts (color, X & Y offsets, etc.), but their respective values will differ. Furthermore, each part's value (which is also known as a "sub-value") is always of the same type. A shadow's color must always be a [color](#color) value, its X offset must always be a [dimension](#dimension) value, and so on. Shadow styles are therefore combinations of values _that follow a pre-defined structure_. In other words, shadow styles are themselves a type. We call types like this **composite types**.
+Every shadow style has the exact same parts (color, X & Y offsets, etc.), but their respective values will differ. Furthermore, each part's value (which is also known as a "sub-value") is always of the same type. A shadow's color must always be a [color](#color) value, its X offset must always be a [dimension](#dimension) value, and so on. Shadow styles are therefore combinations of values _that follow a pre-defined structure_. In other words, shadow styles are themselves a type. Types like this are called **composite types**.
 
 Specifically, a composite type has the following characteristics:
 

--- a/technical-reports/format/composite-types.md
+++ b/technical-reports/format/composite-types.md
@@ -243,7 +243,7 @@ Represents a typographic style. The type property must be set to the string “t
 
 - `fontName`: The typography's font. The value of this property must be a valid [font name](#font-name) or a reference to a font name token.
 - `fontSize`: The size of the typography. The value of this property must be a valid [dimension value](#dimension) or a reference to a dimension token.
-- `fontWeight`: The weight of the typography. The value of this property must be a valid JSON string or a reference to a string token.
+- `fontWeight`: The weight of the typography. The value of this property must be a valid [font weight](#font-weight) or a reference to a font weight token.
 - `letterSpacing`: The horizontal spacing between characters. The value of this property must be a valid [dimension value](#dimension) or a reference to a dimension token.
 - `lineHeight`: The vertical spacing between lines of typography. The value of this property must be a valid JSON string or a reference to a string token.
 

--- a/technical-reports/format/composite-types.md
+++ b/technical-reports/format/composite-types.md
@@ -91,7 +91,11 @@ At first glance, groups and composite tokens might look very similar. However, t
 
 # Border
 
-TO-DO
+Represents a border style. The type property must be set to the string “border”. The value must be an object with the following properties:
+
+- `color`: The color of the border. The value of this property must be a valid [color value](#color) or a reference to a color token.
+- `width`: The width or thickness of the border. The value of this property must be a valid [dimension value](#dimension) or a reference to a dimension token.
+- `style`: The border's style, for example "solid" or "dashed". The value of this property must be a valid JSON string or a reference to another string token.
 
 # Transition
 

--- a/technical-reports/format/composite-types.md
+++ b/technical-reports/format/composite-types.md
@@ -1,57 +1,73 @@
 # Composite types
 
-<div class="issue" data-number="54" title="Should composites be part of the MVP specification?">
+The types defined in the previous chapters such as color and dimension all have singular values. For example, the value of a color token is _one_ color. However, there are other aspects of UI designs that are a combination of multiple values. For instance, a shadow style is a combination of a color, X & Y offsets, a blur radius and a spread radius.
 
-If so, which composites should be included initially?
+Every shadow style has the exact same parts (color, X & Y offsets, etc.), but their respective values will differ. Furthermore, each part's value (which is also known as a "sub-value") is always of the same type. A shadow's color must always be a [color](#color) value, its X offset must always be a [dimension](#dimension) value, and so on. Shadow styles are therefore combinations of values _that follow a pre-defined structure_. In other words, shadow styles are themselves a type. We call types like this **composite types**.
 
-- Would composites allow for better integration with design tools?
-- How would user-defined composites be rendered within design tools?
+Specifically, a composite type has the following characteristics:
 
-</div>
+- Its value is an object containing sub-values.
+- Each sub-value has a pre-defined name and type.
+- Sub-values may be explicit values (e.g. `"#ff0000"`) or references to other design tokens that have sub-value's type (e.g. `"{some.other.token}"`).
 
-The types described in the previous chapter are all for singular values (a color, a dimension, etc.). However, it can often be useful to group related values as a single token so that they can be used or referenced as a single unit. A typical example of this is a “typography style” as found in many design tools, which is a combination of the font name, weight, style, and color.
+A design token whose type happens to be a composite type is sometimes also called a composite (design) token. Besides their type, there is nothing special about composite tokens. They can have all the other additional properties like [description](#description) or [extensions](#extensions). They can also be referenced by other design tokens.
 
-Other examples might be:
-
-- **color pairs**, e.g. a combination of foreground and background color
-- **shadows**, e.g. a combination of color, blur (a dimension value), x & y offsets (also dimension values), and opacity (a number value)
-- **border styles**, e.g. a combination of color, style & thickness
-- **color schemes**
-- **text styles**, e.g. a combination of font and other font properties
-
-<aside class="example" title="Custom type definitions">
+<aside class="example" title="Composite token exmple">
 
 ```json
 {
-  "my types": {
-    "color pair": {
-      "type": "typedef",
+  "shadow-token": {
+    "type": "shadow",
+    "value": {
+      "color": "#00000088",
+      "x": "0.5rem",
+      "y": "0.5rem",
+      "blur": "1.5rem",
+      "spread": "0rem"
+    }
+  }
+}
+```
+
+</aside>
+
+<aside class="example" title="Advanced composite token example">
+
+```json
+{
+  "space": {
+    "small": {
+      "type": "dimension",
+      "value": "0.5rem"
+    }
+  },
+
+  "color": {
+    "shadow-050": {
+      "type": "color",
+      "value": "#00000088"
+    }
+  },
+
+  "shadow": {
+    "medium": {
+      "type": "shadow",
+      "description": "A composite token where some sub-values are references to tokens that have the correct type and others are explicit values",
       "value": {
-        "foreground": {
-          "type": "color",
-          "required": true
-        },
-        "background": {
-          "type": "color",
-          "required": true
-        }
+        "color": "{color.shadow-050}",
+        "x": "{space.small}",
+        "y": "{space.small}",
+        "blur": "1.5rem",
+        "spread": "0rem"
       }
     }
   },
 
-  "layer style": {
-    "body": {
-      "type": "{my types.color pair}",
-      "value": {
-        "foreground": "#333333",
-        "background": "#ffffff"
-      }
-    },
+  "component": {
     "card": {
-      "type": "{my types.color pair}",
-      "value": {
-        "foreground": "#111111",
-        "background": "#eeeeee"
+      "box-shadow": {
+        "description": "This token is an alias for the composite token {shadow.medium}",
+        "value": "{shadow.medium}"
       }
     }
   }
@@ -60,155 +76,41 @@ Other examples might be:
 
 </aside>
 
-## Benefits of composite types over groups
+## Groups versus composite tokens
 
-At first glance, groups and composite types might look very similar. However, they are intended to solve different problems and therefore have some important differences:
+At first glance, groups and composite tokens might look very similar. However, they are intended to solve different problems and therefore have some important differences:
 
-- Groups are for arbitrarily grouping tokens for the purposes of naming and/or organization.
+- **[Groups](#groups)** are for arbitrarily grouping tokens for the purposes of naming and/or organization.
   - They impose no rules or restrictions on how many tokens or nested groups you put within them, what they are called, or what the types of the tokens within should be. As such, tools MUST NOT try to infer any special meaning or typing of tokens based on a group they happen to be in.
   - Different design systems are likely to group their tokens differently.
   - You can think of groups as containers that exist "outside" of design tokens.
-- Composite tokens are individual tokens whose value is made up of several sub-values following a predefined structure.
-  - The values of different composite tokens that share the same type are guaranteed to have the same internal structure (unlike multiple groups, where there is no guarantee whatsoever of how their contents are structured). Tools can therefore check their validity and potentially apply specialized processing or presentation to composite tokens.
-  - You can think of a composite type as something "inside" an individual token.
+- **Composite tokens** are individual design tokens whose values are made up of several sub-values.
+  - Since they are design tokens, they can be referenced by other design tokens. This is not true for groups.
+  - Their type must be one of the composite types defined in this specification. Therefore their names and types of their sub-values are pre-defined. Adding additional sub-values or setting values that don't have the correct type make the composite token invalid.
+  - Tools MAY provide specialised functionality for composite tokens. For example, a design tool may let the user pick from a list of all available shadow tokens when applying a drop shadow effect to an element.
 
-## Type checking
+# Border
 
-Just as with “normal” types for tokens, using a custom, composite type will allow tools to check that the values you use match the expected type. In our color pair example above, attempting to do the following would be invalid and tools should ignore the token and show an error to the user, since “Comic Sans MS” is not a valid color value.
+TO-DO
 
-<aside class="example" title="Invalid type">
+# Transition
 
-```json
-{
-  "broken-token": {
-    "type": "{my types.color pair}",
-    "value": {
-      "foreground": "Comic Sans MS",
-      "background": "#eeeeee"
-    }
-  }
-}
-```
+TO-DO
 
-</aside>
+# Shadow
 
-Likewise, IDEs can offer appropriate auto-completions to users that manually author design token files.
+Represents a shadow style. The type property must be set to the string “shadow”. The value must be an object with the following properties:
 
-## Tool support
+- `color`: The color of the shadow. The value of this property must be a valid [color value](#color) or a reference to a color token.
+- `x`: The horizontal offset that shadow has from the element it is applied to. The value of this property must be a valid [dimension value](#dimension) or a reference to a dimension token.
+- `y`: The vertical offset that shadow has from the element it is applied to. The value of this property must be a valid [dimension value](#dimension) or a reference to a dimension token.
+- `blur`: The blur radius that is applied to the shadow. The value of this property must be a valid [dimension value](#dimension) or a reference to a dimension token.
+- `spread`: The amount by which to expand or contract the shadow. The value of this property must be a valid [dimension value](#dimension) or a reference to a dimension token.
 
-Since composite types are user-defined, tools cannot provide specialized handling of them since they have no advanced knowledge of the type declarations. Here are some suggested strategies to get the most value out of user-defined composite types:
+# Gradient
 
-### Fallbacks
+TO-DO
 
-Given that composite types are ultimately composed of the core design token types, tools that encounter unfamiliar composite tokens could fall back to treating their individual values as separate tokens. In effect, the composite token would be treated the same way as a group of tokens.
+# Text style
 
-Using the color pair type as an example, an export tool like Style Dictionary could just export 2 color variables for it. A token file like this…
-
-<aside class="example" title="JSON source">
-
-```json
-{
-  "My token": {
-    "type": "{my types.color pair}",
-    "value": {
-      "foreground": "#333333",
-      "background": "#ffffff"
-    }
-  }
-}
-```
-
-</aside>
-
-… might be exported to Sass like this:
-
-<aside class="example" title="Sass output with fallback">
-
-```css
-$my-token-foreground: #333333;
-$my-token-background: #ffffff;
-```
-
-</aside>
-
-In a similar vein, a <abbr title="Graphical User Interface">GUI</abbr> tool can "pluck" out the individual values of a composite token and use them as it would normally.
-
-E.g. a design tool like Figma might not have the concept of a color pair, so it can't do anything special with tokens of that type. However, that doesn't prevent it from displaying the foreground and background colors of those tokens alongside any plain color tokens in a color picker.
-
-### Appending custom type definitions
-
-A tool might not understand certain user-defined type definitions in a token file and therefore can't do anything special with them. However, that tool could export or modify token files by adding their own type definitions.
-
-For example, imagine Sketch wanted to export all layer styles from a Sketch document to a token file. The Sketch app could have a built-in type definition that corresponds to layer styles. Perhaps something like this:
-
-<aside class="example" title="Custom type definitions for Sketch">
-
-```json
-{
-  "sketch layer style": {
-    "type": "typedef",
-    "value": {
-      "fill": {
-        "type": "color",
-        "required": false
-      },
-      "border": {
-        "color": {
-          "type": "color",
-          "required": false
-        },
-        "width": {
-          "type": "dimension",
-          "required": false
-        }
-      }
-    }
-  }
-}
-```
-
-</aside>
-
-It could then save out that type definition into the token file it exports. Other tools could then make use of that same type definition and do useful things with tokens of that type.
-
-### Custom configuration
-
-Via configuration files or settings menus, tools could let users define custom behavior for types they have defined. For instance, in an export tool like Style Dictionary, users might be able to configure a custom transform or formatter for their composite types.
-Then, this example...
-
-<aside class="example" title="Custom configuration source">
-
-```json
-{
-  "My token": {
-    "type": "{my types.color pair}",
-    "value": {
-      "foreground": "#333333",
-      "background": "#ffffff"
-    }
-  }
-}
-```
-
-</aside>
-
-...could be configured to export, for example, a mixin instead of 2 variables:
-
-<aside class="example" title="Custom configuration Sass output">
-
-```css
-@mixin my-token {
-  color: #333333;
-  background-color: #ffffff;
-}
-```
-
-</aside>
-
-The downside is of course that teams need to set up and maintain these configurations themselves.
-
-### GUIs
-
-Since composite types are ultimately composed of the core design token types, a design tool could automatically display an appropriate <abbr title="User Interface">UI</abbr> for creating, editing, or previewing them.
-
-For instance, the color pair example above consists of 2 colors, one with the key `foreground` and the other with the key `background`. A design tool could therefore display two color picker widgets using those keys as the respective labels.
+TO-DO

--- a/technical-reports/format/composite-types.md
+++ b/technical-reports/format/composite-types.md
@@ -6,9 +6,7 @@ Every shadow style has the exact same parts (color, X & Y offsets, etc.), but th
 
 Specifically, a composite type has the following characteristics:
 
-- Its value is an object or array containing sub-values.
-- For object values, each sub-value has a pre-defined name and type.
-- For array values, all elements of the array are sub-values that have the same pre-defined type.
+- Its value is an object or array, potentially containing nested objects or arrays, following a pre-defined structure where the properties of the (nested) object(s) or the elements of the (nested) arrays are sub-values.
 - Sub-values may be explicit values (e.g. `"#ff0000"`) or references to other design tokens that have sub-value's type (e.g. `"{some.other.token}"`).
 
 A design token whose type happens to be a composite type is sometimes also called a composite (design) token. Besides their type, there is nothing special about composite tokens. They can have all the other additional properties like [description](#description) or [extensions](#extensions). They can also be referenced by other design tokens.
@@ -90,7 +88,7 @@ At first glance, groups and composite tokens might look very similar. However, t
   - Their type must be one of the composite types defined in this specification. Therefore their names and types of their sub-values are pre-defined. Adding additional sub-values or setting values that don't have the correct type make the composite token invalid.
   - Tools MAY provide specialised functionality for composite tokens. For example, a design tool may let the user pick from a list of all available shadow tokens when applying a drop shadow effect to an element.
 
-# Border
+## Border
 
 Represents a border style. The type property must be set to the string “border”. The value must be an object with the following properties:
 
@@ -125,11 +123,11 @@ Represents a border style. The type property must be set to the string “border
 
 </aside>
 
-# Transition
+## Transition
 
 TO-DO
 
-# Shadow
+## Shadow
 
 Represents a shadow style. The type property must be set to the string “shadow”. The value must be an object with the following properties:
 
@@ -139,16 +137,14 @@ Represents a shadow style. The type property must be set to the string “shadow
 - `blur`: The blur radius that is applied to the shadow. The value of this property must be a valid [dimension value](#dimension) or a reference to a dimension token.
 - `spread`: The amount by which to expand or contract the shadow. The value of this property must be a valid [dimension value](#dimension) or a reference to a dimension token.
 
-# Gradient Stop
+## Gradient
 
-Represents an individual stop on a color gradient. In practice, this type is unlikely to be useful by itself, but it is required by the [gradient type](#gradient). The value must be an object with the following properties:
+Represents a color gradient. The value must be an array of objects representing gradient stops that have the following structure:
 
 - `color`: The color value at the stop's position on the gradient. The value of this property must be a valid [color value](#color) or a reference to a color token.
 - `position`: The position of the stop along the gradient's axis. The value of this property must be a valid number value or reference to a number token. The number values must be in the range [0, 1], where 0 represents the start position of the gradient's axis and 1 the end position. If a number value outside of that range is given, it MUST be considered as if it were clamped to the range [0, 1]. For example, a value of 42 should be treated as if it were 1, i.e. the end position of the gradient axis. Similarly, a value of -99 should be treated as if it were 0, i.e. the start position of the gradient axis.
 
-# Gradient
-
-Represents a color gradient. The value must be an array of [gradient stops](#gradient-stop). If there are no stops at the very beginning or end of the gradient axis (i.e. with `position` 0 or 1, respectively), then the color from the stop closest to each end should be extended to that end of the axis.
+If there are no stops at the very beginning or end of the gradient axis (i.e. with `position` 0 or 1, respectively), then the color from the stop closest to each end should be extended to that end of the axis.
 
 <aside class="example" title="Gradient token example">
 
@@ -159,11 +155,11 @@ Represents a color gradient. The value must be an array of [gradient stops](#gra
     "value": [
       {
         "color": "#0000ff",
-        "pos": 0
+        "position": 0
       },
       {
         "color": "#ff0000",
-        "pos": 1
+        "position": 1
       }
     ]
   }
@@ -185,11 +181,11 @@ Describes a gradient that goes from blue to red:
     "value": [
       {
         "color": "#ffff00",
-        "pos": 0.666
+        "position": 0.666
       },
       {
         "color": "#ff0000",
-        "pos": 1
+        "position": 1
       }
     ]
   }
@@ -220,15 +216,15 @@ Describes a gradient that is solid yellow for the first 2/3 and then fades to re
     "value": [
       {
         "color": "#000000",
-        "pos": 0
+        "position": 0
       },
       {
         "color": "{brand-primary}",
-        "pos": 0.5
+        "position": 0.5
       },
       {
         "color": "#000000",
-        "pos": "{position-end}"
+        "position": "{position-end}"
       }
     ]
   }
@@ -241,7 +237,7 @@ Describes a color token called "brand-primary", which is referenced as the mid-p
 
 </aside>
 
-# Typography
+## Typography
 
 Represents a typographic style. The type property must be set to the string “typography”. The value must be an object with the following properties:
 

--- a/technical-reports/format/types.md
+++ b/technical-reports/format/types.md
@@ -200,7 +200,6 @@ For example:
 <div class="ednote" title="Additional types">
 Types still to be documented here are likely to include:
 
-- **Font weight:** might be something like an enum of allowed values ("bold", "normal" etc.) and/or numeric values 0-1000 (like in variable fonts)
 - **Font style:** might be an enum of allowed values like ("normal", "italic"...)
 - **Border style/stroke style:** maybe an enum (solid, dashed, dotted, etc.) and/or a way to specify dash & gap lengths?
 - **Percentage/ratio:** e.g. for opacity values, relative dimensions, aspect ratios, etc.

--- a/technical-reports/format/types.md
+++ b/technical-reports/format/types.md
@@ -201,7 +201,6 @@ For example:
 Types still to be documented here are likely to include:
 
 - **Font style:** might be an enum of allowed values like ("normal", "italic"...)
-- **Border style/stroke style:** maybe an enum (solid, dashed, dotted, etc.) and/or a way to specify dash & gap lengths?
 - **Percentage/ratio:** e.g. for opacity values, relative dimensions, aspect ratios, etc.
   - Not 100% sure about this since these are really "just" numbers. An alternative might be that we expand the permitted syntax for the "number" type, so for example "1:2", "50%" and 0.5 are all equivalent. People can then use whichever syntax they like best for a given token.
 - **File:** for assets - might just be a relative file path / URL (or should we let people also express the mime-type?)

--- a/technical-reports/format/types.md
+++ b/technical-reports/format/types.md
@@ -88,7 +88,7 @@ A naive approach like the one below may be appropriate for the first stage of th
 
 </div>
 
-Represents a font name or an array of font names (ordered from most to least preferred). The `type` property must be set to the string "font". The value must either be a string value containing a single font name or an array of strings, each being a single font name.
+Represents a font name or an array of font names (ordered from most to least preferred). The `type` property must be set to the string "font-name". The value must either be a string value containing a single font name or an array of strings, each being a single font name.
 
 For example:
 
@@ -98,11 +98,51 @@ For example:
 {
   "Primary font": {
     "value": "Comic Sans MS",
-    "type": "font"
+    "type": "font-name"
   },
   "Body font": {
     "value": ["Helvetica", "Arial"],
-    "type": "font"
+    "type": "font-name"
+  }
+}
+```
+
+</aside>
+
+## Font weight
+
+Represents a font weight. The `type` property must be set to the string "font-weight". The value must either be a number value in the range [1, 1000] or one of the pre-defined string values defined in the table below.
+
+Lower numbers represent lighter weights, and higher numbers represent thicker weights, as per the [OpenType `wght` tag specification](https://docs.microsoft.com/en-us/typography/opentype/spec/dvaraxistag_wght). The pre-defined string values are aliases for specific numeric values. For example `100`, `"thin"` and `"hairline"` are all the exact same value.
+
+| numeric value | string value aliases         |
+| ------------- | ---------------------------- |
+| `100`         | `thin`, `hairline`           |
+| `200`         | `extra-light`, `ultra-light` |
+| `300`         | `light`                      |
+| `400`         | `normal`, `regular`, `book`  |
+| `500`         | `medium`                     |
+| `600`         | `semi-bold`, `demi-bold`     |
+| `700`         | `bold`                       |
+| `800`         | `extra-bold`, `ultra-bold`   |
+| `900`         | `black`, `heavy`             |
+| `950`         | `extra-black`, `ultra-black` |
+
+Number values outside of the [1, 1000] range and any other string values, including ones that differ only in case, are invalid and MUST be rejected by tools.
+
+Example:
+
+<aside class="example">
+
+```json
+{
+  "font-weight-default": {
+    "value": 350,
+    "type": "font-weight"
+  },
+  "font-weight-thick": {
+    "value": "extra-bold",
+    "type": "font-weight"
   }
 }
 ```

--- a/technical-reports/format/types.md
+++ b/technical-reports/format/types.md
@@ -80,7 +80,7 @@ The "px" and "rem" units are to be interpreted the same way they are in CSS:
 - **px**: Represents an idealized pixel on the viewport. The equivalent in Android is dp and iOS is pt. Export tools SHOULD therefore convert to these or other equivalent units as needed.
 - **rem**: Represents a multiple of the system's default font size (which MAY be configurable by the user). 1rem is 100% of the default font size. The equivalent of 1rem on Android is 16sp. Not all platforms have an equivalent to rem, so export tools MAY need to do a lossy conversion to a fixed px size by assuming a default font size (usually 16px) for such platforms.
 
-## Font name
+## Font family
 
 <div class="issue" data-number="53">
 
@@ -88,7 +88,7 @@ A naive approach like the one below may be appropriate for the first stage of th
 
 </div>
 
-Represents a font name or an array of font names (ordered from most to least preferred). The `type` property MUST be set to the string "font-name". The value MUST either be a string value containing a single font name or an array of strings, each being a single font name.
+Represents a font name or an array of font names (ordered from most to least preferred). The `type` property MUST be set to the string "fontFamily". The value MUST either be a string value containing a single font name or an array of strings, each being a single font name.
 
 For example:
 
@@ -98,11 +98,11 @@ For example:
 {
   "Primary font": {
     "value": "Comic Sans MS",
-    "type": "font-name"
+    "type": "fontFamily"
   },
   "Body font": {
     "value": ["Helvetica", "Arial"],
-    "type": "font-name"
+    "type": "fontFamily"
   }
 }
 ```


### PR DESCRIPTION
Closes #54 

The format editors have decided to keep the concept of composite types in the draft spec. However, we will replace the mechanism for user-defined composite types with a set of pre-defined composite types. (Future spec versions may bring back user-defined (composite) types if there is demand for it).