### PR TITLE
Capitalize RFC 2119 keywords when appropriate

### DIFF
--- a/technical-reports/format/aliases.md
+++ b/technical-reports/format/aliases.md
@@ -7,7 +7,7 @@ Aliases are useful for:
 - Expressing design choices
 - Eliminating repetition of values in token files (DRYing up the code)
 
-For a design token to reference another, its value should be a string containing the period-separated (.) path to the token it's referencing enclosed in curly brackets.
+For a design token to reference another, its value SHOULD be a string containing the period-separated (.) path to the token it's referencing enclosed in curly brackets.
 
 For example:
 
@@ -28,11 +28,11 @@ For example:
 
 </aside>
 
-When a tool needs the actual value of a token it must resolve the reference - i.e. lookup the token being referenced and fetch its value. In the above example, the "alias name" token's value would resolve to 1234 because it references the token whose path is `{group name.token name}` which has the value 1234.
+When a tool needs the actual value of a token it MUST resolve the reference - i.e. lookup the token being referenced and fetch its value. In the above example, the "alias name" token's value would resolve to 1234 because it references the token whose path is `{group name.token name}` which has the value 1234.
 
-Tools should preserve references and therefore only resolve them whenever the actual value needs to be retrieved. For instance, in a design tool, changes to the value of a token being referenced by aliases should be reflected wherever those aliases are being used.
+Tools SHOULD preserve references and therefore only resolve them whenever the actual value needs to be retrieved. For instance, in a design tool, changes to the value of a token being referenced by aliases SHOULD be reflected wherever those aliases are being used.
 
-Aliases may reference other aliases. In this case, tools should follow each reference until they find a token with an explicit value. Circular references are not allowed. If a design token file contains circular references, then the value of all tokens in that chain is unknown and an appropriate error or warning message should be displayed to the user.
+Aliases MAY reference other aliases. In this case, tools SHOULD follow each reference until they find a token with an explicit value. Circular references are not allowed. If a design token file contains circular references, then the value of all tokens in that chain is unknown and an appropriate error or warning message SHOULD be displayed to the user.
 
 <p class="ednote" title="JSON Pointer syntax">
   The format editors are currently researching JSON Pointer syntax to inform the exact syntax for aliases in tokens. <a href="https://datatracker.ietf.org/doc/html/rfc6901#section-5">https://datatracker.ietf.org/doc/html/rfc6901#section-5</a>

--- a/technical-reports/format/aliases.md
+++ b/technical-reports/format/aliases.md
@@ -7,7 +7,7 @@ Aliases are useful for:
 - Expressing design choices
 - Eliminating repetition of values in token files (DRYing up the code)
 
-For a design token to reference another, its value SHOULD be a string containing the period-separated (.) path to the token it's referencing enclosed in curly brackets.
+For a design token to reference another, its value MUST be a string containing the period-separated (.) path to the token it's referencing enclosed in curly brackets.
 
 For example:
 
@@ -32,7 +32,7 @@ When a tool needs the actual value of a token it MUST resolve the reference - i.
 
 Tools SHOULD preserve references and therefore only resolve them whenever the actual value needs to be retrieved. For instance, in a design tool, changes to the value of a token being referenced by aliases SHOULD be reflected wherever those aliases are being used.
 
-Aliases MAY reference other aliases. In this case, tools SHOULD follow each reference until they find a token with an explicit value. Circular references are not allowed. If a design token file contains circular references, then the value of all tokens in that chain is unknown and an appropriate error or warning message SHOULD be displayed to the user.
+Aliases MAY reference other aliases. In this case, tools MUST follow each reference until they find a token with an explicit value. Circular references are not allowed. If a design token file contains circular references, then the value of all tokens in that chain is unknown and an appropriate error or warning message SHOULD be displayed to the user.
 
 <p class="ednote" title="JSON Pointer syntax">
   The format editors are currently researching JSON Pointer syntax to inform the exact syntax for aliases in tokens. <a href="https://datatracker.ietf.org/doc/html/rfc6901#section-5">https://datatracker.ietf.org/doc/html/rfc6901#section-5</a>

--- a/technical-reports/format/design-token.md
+++ b/technical-reports/format/design-token.md
@@ -36,7 +36,7 @@ Token names are case-sensitive, so the following example with 2 tokens in the sa
 
 </aside>
 
-However, some tools may need to transform names when exporting to other languages or displaying names to the user, so having token names that differ only in case is likely to cause identical and undesirable duplicates in the output. For example, an export tool that converts these tokens to Sass code may generate problematic output like this:
+However, some tools MAY need to transform names when exporting to other languages or displaying names to the user, so having token names that differ only in case is likely to cause identical and undesirable duplicates in the output. For example, an export tool that converts these tokens to Sass code would generate problematic output like this:
 
 <aside class="example">
 
@@ -62,7 +62,7 @@ Due to the syntax used for [token aliases](#aliases-references) the following ch
 
 ### Token value type
 
-Token values may be any valid JSON type:
+Token values MUST be a valid JSON type:
 
 - `string`
 - `number`
@@ -71,14 +71,14 @@ Token values may be any valid JSON type:
 - `boolean`
 - `null`
 
-Additionally, tokens may be defined with a more specific [Token Type](#types)
+Additionally, tokens MAY be defined with a more specific [Token Type](#types)
 
 <div class="issue" data-number="55" title="Object vs Array">
 
 The structure in the example above is a JSON object, an **unordered** set of name/value pairs.
 
 - Objects can't contain members with duplicate keys
-- Ordering of object members may not be preserved (as per [RFC 7159](https://tools.ietf.org/html/rfc7159#section-4)), meaning token retrieval may or may not result in the same ordering as the input
+- Ordering of object members MAY NOT be preserved (as per [RFC 7159](https://tools.ietf.org/html/rfc7159#section-4)), meaning token retrieval MAY or MAY NOT result in the same ordering as the input
 
 Please raise concerns if these limitations create problems for implementers.
 
@@ -90,7 +90,7 @@ Please raise concerns if these limitations create problems for implementers.
 
 ## Additional properties
 
-While "value" is the only required property for a token, a number of additional properties may be added:
+While "value" is the only required property for a token, a number of additional properties MAY be added:
 
 ## Description
 
@@ -98,12 +98,12 @@ A plain text description explaining the token's purpose. Tools MAY use the descr
 
 For example:
 
-- Style guide generators could display the description text alongside a visual preview of the token
-- IDEs might display the description as a tooltip for auto-completion (similar to how API docs are displayed)
-- Design tools might display the description as a tooltip or alongside tokens wherever they can be selected
-- Export tools might render the description to a source code comment alongside the variable or constant they export.
+- Style guide generators MAY display the description text alongside a visual preview of the token
+- IDEs MAY display the description as a tooltip for auto-completion (similar to how API docs are displayed)
+- Design tools MAY display the description as a tooltip or alongside tokens wherever they can be selected
+- Export tools MAY render the description to a source code comment alongside the variable or constant they export.
 
-The **description** property must be a plain JSON string, for example:
+The **description** property MUST be a plain JSON string, for example:
 
 <aside class="example">
 
@@ -139,7 +139,7 @@ The `type` property can be set on different levels:
 - at the group level
 - at the token level
 
-The `type` property must be a plain JSON string, whose value is one of the [types](#types) defined in this specification.
+The `type` property MUST be a plain JSON string, whose value is one of the [types](#types) defined in this specification.
 
 For example:
 
@@ -158,7 +158,7 @@ For example:
 
 ## Extensions
 
-The **extensions** property is an object where tools MAY add proprietary, user-, team- or vendor-specific data to a design token. When doing so, each tool MUST use a vendor-specific key whose value may be any valid JSON data.
+The **extensions** property is an object where tools MAY add proprietary, user-, team- or vendor-specific data to a design token. When doing so, each tool MUST use a vendor-specific key whose value MAY be any valid JSON data.
 
 - The keys SHOULD be chosen such that they avoid the likelihood of a naming clash with another vendor's data. The [reverse domain name notation](https://en.wikipedia.org/wiki/Reverse_domain_name_notation) is recommended for this purpose.
 - Tools that process design token files MUST preserve any extension data they do not themselves understand. For example, if a design token contains extension data from tool A and the file containing that data is opened by tool B, then tool B MUST include the original tool A extension data whenever it saves a new design token file containing that token.
@@ -181,9 +181,9 @@ The **extensions** property is an object where tools MAY add proprietary, user-,
 
 </aside>
 
-In order to maintain interoperability between tools that support this format, teams and tools should restrict their usage of extension data to optional meta-data that is not crucial to understanding that token's value.
+In order to maintain interoperability between tools that support this format, teams and tools SHOULD restrict their usage of extension data to optional meta-data that is not crucial to understanding that token's value.
 
-Tool vendors are encouraged to publicly share specifications of their extension data wherever possible. That way other tools can add support for them without needing to reverse engineer the extension data. Popular extensions may also be incorporated as standardized features in future revisions of this specification.
+Tool vendors are encouraged to publicly share specifications of their extension data wherever possible. That way other tools can add support for them without needing to reverse engineer the extension data. Popular extensions could also be incorporated as standardized features in future revisions of this specification.
 
 <p class="ednote" title="Extensions section">
   The extensions section is not limited to vendors. All token users can add additional data in this section for their own purposes.

--- a/technical-reports/format/design-token.md
+++ b/technical-reports/format/design-token.md
@@ -60,25 +60,12 @@ Due to the syntax used for [token aliases](#aliases-references) the following ch
 - `}` (right curly bracket)
 - `.` (period)
 
-### Token value type
-
-Token values MUST be a valid JSON type:
-
-- `string`
-- `number`
-- `array`
-- `object`
-- `boolean`
-- `null`
-
-Additionally, tokens MAY be defined with a more specific [Token Type](#types)
-
 <div class="issue" data-number="55" title="Object vs Array">
 
 The structure in the example above is a JSON object, an **unordered** set of name/value pairs.
 
 - Objects can't contain members with duplicate keys
-- Ordering of object members MAY NOT be preserved (as per [RFC 7159](https://tools.ietf.org/html/rfc7159#section-4)), meaning token retrieval MAY or MAY NOT result in the same ordering as the input
+- Ordering of object members is not guaranteed (as per [RFC 7159](https://tools.ietf.org/html/rfc7159#section-4))
 
 Please raise concerns if these limitations create problems for implementers.
 

--- a/technical-reports/format/file-format.md
+++ b/technical-reports/format/file-format.md
@@ -10,11 +10,11 @@ JSON was chosen as an interchange format on the basis of:
 
 ## Media type (MIME type)
 
-When serving design token files via HTTP / HTTPS or in any other scenario where a media type (formerly known as MIME type) needs to be specified, the following MIME type should be used for design token files:
+When serving design token files via HTTP / HTTPS or in any other scenario where a media type (formerly known as MIME type) needs to be specified, the following MIME type SHOULD be used for design token files:
 
 - `application/design-tokens+json`
 
-However, since every design token file is a valid JSON file and it may not always be possible to configure web servers as needed, it is also acceptable to use the plain JSON media type: `application/json`. The above, more specific media type is preferred and should be used wherever possible.
+However, since every design token file is a valid JSON file, they MAY be served using the JSON media type: `application/json`. The above, more specific media type is preferred and SHOULD be used wherever possible.
 
 Tools that can open design token files MUST support both media types.
 

--- a/technical-reports/format/groups.md
+++ b/technical-reports/format/groups.md
@@ -1,6 +1,6 @@
 # Groups
 
-A file may contain many tokens and they may be nested arbitrarily in groups like so:
+A file MAY contain many tokens and they MAY be nested arbitrarily in groups like so:
 
 <aside class="example">
 
@@ -27,7 +27,7 @@ A file may contain many tokens and they may be nested arbitrarily in groups like
 
 </aside>
 
-The names of the groups leading to a given token (including that token's name) are that token's _path_, which is a computed property. **It is not specified in the file**, but parsers that conform to this spec must be able to expose the path of a token. The above example, therefore, defines 4 design tokens with the following properties:
+The names of the groups leading to a given token (including that token's name) are that token's _path_, which is a computed property. **It is not specified in the file**, but parsers that conform to this spec MUST be able to expose the path of a token. The above example, therefore, defines 4 design tokens with the following properties:
 
 - Token #1
   - Name: "token uno"
@@ -60,7 +60,7 @@ The names of items in a group are case sensitive. As per the guidance in the [de
 
 ### Description
 
-Groups may include an optional `description` property.
+Groups MAY include an optional `description` property.
 
 For example:
 
@@ -85,7 +85,7 @@ For example:
 
 </aside>
 
-Suggested ways tools may use this property are:
+Suggested ways tools MAY use this property are:
 
 - A style guide generator could render a section for each group and use the description as an introductory paragraph
 - A GUI tool that lets users browse or select tokens could display this info alongside the corresponding group or as a tooltip
@@ -99,7 +99,7 @@ Groups may support additional properties like type and description. Should other
 
 ### Type
 
-Groups may include an optional `type` property so a type property does not need to be manually added to every token. [See supported "Types"](#types) for more information.
+Groups MAY include an optional `type` property so a type property does not need to be manually added to every token. [See supported "Types"](#types) for more information.
 
 If a group has a `type` property it acts as a default type for any tokens within the group, including ones in nested groups, that do not explicity declare a type via their own `type` property. For the full set of rules by which a design token's type is determined, please refer to the [design token type property chapter](#type-0).
 
@@ -186,13 +186,13 @@ For example:
 
 ### GUI tools
 
-Tools that let users pick or edit tokens via a GUI may use the grouping structure to display a suitable form of progressive disclosure, such as a collapsible tree view.
+Tools that let users pick or edit tokens via a GUI MAY use the grouping structure to display a suitable form of progressive disclosure, such as a collapsible tree view.
 
 ![Progressive disclosure groups](./group-progressive-disclosure.png)
 
 ### Export tools
 
-Token names are not guaranteed to be unique within the same file. The same name can be used in different groups. Also, export tools may need to export design tokens in a uniquely identifiable way, such as variables in code. Export tools should therefore use design tokens' paths as these _are_ unique within a file.
+Token names are not guaranteed to be unique within the same file. The same name can be used in different groups. Also, export tools MAY need to export design tokens in a uniquely identifiable way, such as variables in code. Export tools SHOULD therefore use design tokens' paths as these _are_ unique within a file.
 
 For example, a [translation tool](#translation-tool) like [Style Dictionary](https://amzn.github.io/style-dictionary/) might use the following design token file:
 

--- a/technical-reports/format/terminology.md
+++ b/technical-reports/format/terminology.md
@@ -11,7 +11,7 @@ Few examples:
 - `color-text-primary: #000000;`
 - `font-size-heading-level-1: 44px;`
 
-The name MAY be associated with additional [Token Properties](#design-token-properties).
+The name may be associated with additional [Token Properties](#design-token-properties).
 
 <h2 id="design-token-properties">(Design) Token Properties</h2>
 

--- a/technical-reports/format/terminology.md
+++ b/technical-reports/format/terminology.md
@@ -11,7 +11,7 @@ Few examples:
 - `color-text-primary: #000000;`
 - `font-size-heading-level-1: 44px;`
 
-The name may be associated with additional [Token Properties](#design-token-properties).
+The name MAY be associated with additional [Token Properties](#design-token-properties).
 
 <h2 id="design-token-properties">(Design) Token Properties</h2>
 

--- a/technical-reports/format/types.md
+++ b/technical-reports/format/types.md
@@ -1,6 +1,6 @@
 # Types
 
-Many tools need to know what kind of value a given token represents to process it sensibly. Export tools may need to convert or format tokens differently depending on their type. Design tools may present the user with different kinds of input when editing tokens of a certain type (such as color picker, slider, text input, etc.). Style guide generators may use different kinds of previews for different types of tokens.
+Many tools need to know what kind of value a given token represents to process it sensibly. Export tools MAY need to convert or format tokens differently depending on their type. Design tools MAY present the user with different kinds of input when editing tokens of a certain type (such as color picker, slider, text input, etc.). Style guide generators MAY use different kinds of previews for different types of tokens.
 
 Since design token files are JSON files, all the basic JSON types are available:
 
@@ -11,17 +11,17 @@ Since design token files are JSON files, all the basic JSON types are available:
 - Boolean
 - Null
 
-Additionally, this spec defines a number of more design-focused types. To set a token to one of these types, it MUST have a type property specifying the chosen type. Furthermore, that token's value must then follow rules and syntax for the chosen type as defined by this spec.
+Additionally, this spec defines a number of more design-focused types. To set a token to one of these types, it MUST have a type property specifying the chosen type. Furthermore, that token's value MUST then follow rules and syntax for the chosen type as defined by this spec.
 
 If the `type` property is absent, tools MUST treat values as one of the basic JSON types and not attempt to infer any other type from the value.
 
-If a `type` is set, but the value does not match the expected syntax then that token is invalid and an appropriate error should be displayed to the user. To put it another way, the `type` property is a declaration of what kind of values are permissible for the token. (This is similar to typing in programming languages like Java or TypeScript, where a value not compatible with the declared type causes a compilation error).
+If a `type` is set, but the value does not match the expected syntax then that token is invalid and an appropriate error SHOULD be displayed to the user. To put it another way, the `type` property is a declaration of what kind of values are permissible for the token. (This is similar to typing in programming languages like Java or TypeScript, where a value not compatible with the declared type causes a compilation error).
 
 ## Color
 
-Represents a 24bit RGB or 24+8bit RGBA color in the sRGB color space. The `type` property must be set to the string "color". The value must be a string containing a hex triplet/quartet including the preceding # character. To support other color spaces, such as HSL, export tools should convert color tokens to the equivalent value as needed.
+Represents a 24bit RGB or 24+8bit RGBA color in the sRGB color space. The `type` property MUST be set to the string "color". The value MUST be a string containing a hex triplet/quartet including the preceding # character. To support other color spaces, such as HSL, export tools SHOULD convert color tokens to the equivalent value as needed.
 
-For example, initially the color tokens may be defined as such:
+For example, initially the color tokens MAY be defined as such:
 
 <aside class="example">
 
@@ -40,7 +40,7 @@ For example, initially the color tokens may be defined as such:
 
 </aside>
 
-Then, the output from a tool's conversion to HSL(A) may look something like:
+Then, the output from a tool's conversion to HSL(A) MAY look something like:
 
 <aside class="example">
 
@@ -58,7 +58,7 @@ $translucent-shadow: hsla(300, 100%, 50%, 0.5);
 
 ## Dimension
 
-Represents an amount of distance in a single dimension in the UI, such as a position, width, height, radius, or thickness. The `type` property must be set to the string "dimension". The value must be a string containing a number (either integer or floating-point) followed by either a "px" or "rem" unit (future spec iterations may add support for additional units).
+Represents an amount of distance in a single dimension in the UI, such as a position, width, height, radius, or thickness. The `type` property must be set to the string "dimension". The value must be a string containing a number (either integer or floating-point) followed by either a "px" or "rem" unit (future spec iterations MAY add support for additional units).
 
 For example:
 
@@ -77,18 +77,18 @@ For example:
 
 The "px" and "rem" units are to be interpreted the same way they are in CSS:
 
-- **px**: Represents an idealized pixel on the viewport. The equivalent in Android is dp and iOS is pt. Export tools should therefore convert to these or other equivalent units as needed.
-- **rem**: Represents a multiple of the system's default font size (which may be configurable by the user). 1rem is 100% of the default font size. The equivalent of 1rem on Android is 16sp. Not all platforms have an equivalent to rem, so export tools may need to do a lossy conversion to a fixed px size by assuming a default font size (usually 16px) for such platforms.
+- **px**: Represents an idealized pixel on the viewport. The equivalent in Android is dp and iOS is pt. Export tools SHOULD therefore convert to these or other equivalent units as needed.
+- **rem**: Represents a multiple of the system's default font size (which MAY be configurable by the user). 1rem is 100% of the default font size. The equivalent of 1rem on Android is 16sp. Not all platforms have an equivalent to rem, so export tools MAY need to do a lossy conversion to a fixed px size by assuming a default font size (usually 16px) for such platforms.
 
 ## Font name
 
 <div class="issue" data-number="53">
 
-A naive approach like the one below may be appropriate for the first stage of the specification, but this may be more complicated than it seems due to platform/OS/browser restrictions.
+A naive approach like the one below MAY be appropriate for the first stage of the specification, but this could be more complicated than it seems due to platform/OS/browser restrictions.
 
 </div>
 
-Represents a font name or an array of font names (ordered from most to least preferred). The `type` property must be set to the string "font". The value must either be a string value containing a single font name or an array of strings, each being a single font name.
+Represents a font name or an array of font names (ordered from most to least preferred). The `type` property MUST be set to the string "font". The value MUST either be a string value containing a single font name or an array of strings, each being a single font name.
 
 For example:
 
@@ -111,7 +111,7 @@ For example:
 
 ## Duration
 
-Represents the length of time in milliseconds an animation or animation cycle takes to complete, such as 200 milliseconds. The `type` property must be set to the string "duration". The value must be a string containing a number (either integer or floating-point) followed by an "ms" unit. A millisecond is a unit of time equal to one thousandth of a second.
+Represents the length of time in milliseconds an animation or animation cycle takes to complete, such as 200 milliseconds. The `type` property MUST be set to the string "duration". The value MUST be a string containing a number (either integer or floating-point) followed by an "ms" unit. A millisecond is a unit of time equal to one thousandth of a second.
 
 For example:
 
@@ -134,7 +134,7 @@ For example:
 
 ## Cubic Bézier
 
-Represents how the value of an animated property progresses towards completion over the duration of an animation, effectively creating visual effects such as acceleration, deceleration, and bounce. The `type` property must be set to the string "cubic-bezier". The value must be an array containing four numbers. These numbers represent two points (P1, P2) with one x coordinate and one y coordinate each [P1x, P1y, P2x, P2y]. The y coordinates of P1 and P2 can be any real number in the range [-∞, ∞], but the x coordinates are restricted to the range [0, 1].
+Represents how the value of an animated property progresses towards completion over the duration of an animation, effectively creating visual effects such as acceleration, deceleration, and bounce. The `type` property MUST be set to the string "cubic-bezier". The value MUST be an array containing four numbers. These numbers represent two points (P1, P2) with one x coordinate and one y coordinate each [P1x, P1y, P2x, P2y]. The y coordinates of P1 and P2 can be any real number in the range [-∞, ∞], but the x coordinates are restricted to the range [0, 1].
 
 For example:
 
@@ -155,9 +155,10 @@ For example:
 
 </aside>
 
+<section class="informative">
+
 ## Additional types
 
-<div class="ednote" title="Additional types">
 Types still to be documented here are likely to include:
 
 - **Font weight:** might be something like an enum of allowed values ("bold", "normal" etc.) and/or numeric values 0-1000 (like in variable fonts)
@@ -167,4 +168,5 @@ Types still to be documented here are likely to include:
   - Not 100% sure about this since these are really "just" numbers. An alternative might be that we expand the permitted syntax for the "number" type, so for example "1:2", "50%" and 0.5 are all equivalent. People can then use whichever syntax they like best for a given token.
 - **File:** for assets - might just be a relative file path / URL (or should we let people also express the mime-type?)
 - **Easing definitions:** for animation
-</div>
+
+</section>

--- a/technical-reports/format/types.md
+++ b/technical-reports/format/types.md
@@ -58,7 +58,7 @@ $translucent-shadow: hsla(300, 100%, 50%, 0.5);
 
 ## Dimension
 
-Represents an amount of distance in a single dimension in the UI, such as a position, width, height, radius, or thickness. The `type` property must be set to the string "dimension". The value must be a string containing a number (either integer or floating-point) followed by either a "px" or "rem" unit (future spec iterations MAY add support for additional units).
+Represents an amount of distance in a single dimension in the UI, such as a position, width, height, radius, or thickness. The `type` property must be set to the string "dimension". The value must be a string containing a number (either integer or floating-point) followed by either a "px" or "rem" unit (future spec iterations may add support for additional units).
 
 For example:
 
@@ -84,7 +84,7 @@ The "px" and "rem" units are to be interpreted the same way they are in CSS:
 
 <div class="issue" data-number="53">
 
-A naive approach like the one below MAY be appropriate for the first stage of the specification, but this could be more complicated than it seems due to platform/OS/browser restrictions.
+A naive approach like the one below may be appropriate for the first stage of the specification, but this could be more complicated than it seems due to platform/OS/browser restrictions.
 
 </div>
 


### PR DESCRIPTION
Fixes #77

This PR also introduces a few edits, to try and use less ambiguous keywords when possible, or to make it clear that one of the sections isn't normative.