### PR TITLE
Adds `$` prefix and standardises on camelCase

### DIFF
--- a/technical-reports/format/aliases.md
+++ b/technical-reports/format/aliases.md
@@ -17,11 +17,11 @@ For example:
 {
   "group name": {
     "token name": {
-      "value": 1234
+      "$value": 1234
     }
   },
   "alias name": {
-    "value": "{group name.token name}"
+    "$value": "{group name.token name}"
   }
 }
 ```

--- a/technical-reports/format/aliases.md
+++ b/technical-reports/format/aliases.md
@@ -7,7 +7,7 @@ Aliases are useful for:
 - Expressing design choices
 - Eliminating repetition of values in token files (DRYing up the code)
 
-For a design token to reference another, its value MUST be a string containing the period-separated (.) path to the token it's referencing enclosed in curly brackets.
+For a design token to reference another, its value MUST be a string containing the period-separated (`.`) path to the token it's referencing enclosed in curly brackets.
 
 For example:
 

--- a/technical-reports/format/composite-types.md
+++ b/technical-reports/format/composite-types.md
@@ -19,8 +19,8 @@ A design token whose type happens to be a composite type is sometimes also calle
     "type": "shadow",
     "value": {
       "color": "#00000088",
-      "offset-x": "0.5rem",
-      "offset-y": "0.5rem",
+      "offsetX": "0.5rem",
+      "offsetY": "0.5rem",
       "blur": "1.5rem",
       "spread": "0rem"
     }
@@ -54,8 +54,8 @@ A design token whose type happens to be a composite type is sometimes also calle
       "description": "A composite token where some sub-values are references to tokens that have the correct type and others are explicit values",
       "value": {
         "color": "{color.shadow-050}",
-        "offset-x": "{space.small}",
-        "offset-y": "{space.small}",
+        "offsetX": "{space.small}",
+        "offsetY": "{space.small}",
         "blur": "1.5rem",
         "spread": "0rem"
       }
@@ -90,7 +90,7 @@ At first glance, groups and composite tokens might look very similar. However, t
 
 ## Stroke style
 
-Represents the style applied to lines or borders. The `type` property must be set to the string `"stroke-style"`. The value must be either:
+Represents the style applied to lines or borders. The `type` property MUST be set to the string `strokeStyle`. The value MUST be either:
 
 - a string value as defined in the corresponding section below, or
 - an object value as defined in the corresponding section below
@@ -119,7 +119,7 @@ These values have the same meaning as the equivalent ["line style" values in CSS
 ```json
 {
   "focus-ring-style": {
-    "type": "stroke-style",
+    "type": "strokeStyle",
     "value": "dashed"
   }
 }
@@ -131,18 +131,18 @@ These values have the same meaning as the equivalent ["line style" values in CSS
 
 Object stroke style values MUST have the following properties:
 
-- `dash-array`: An array of [dimension values](#dimension) and/or references to dimension tokens, which specify the lengths of alternating dashes and gaps. If an odd number of values is provided, then the list of values is repeated to yield an even number of values.
-- `line-cap`: One of the following pre-defined string values: `"round"`, `"butt"` or `"square"`. These values have the same meaning as those of [the `stroke-linecap` attribute in SVG](https://www.w3.org/TR/SVG11/painting.html#StrokeLinecapProperty).
+- `dashArray`: An array of [dimension values](#dimension) and/or references to dimension tokens, which specify the lengths of alternating dashes and gaps. If an odd number of values is provided, then the list of values is repeated to yield an even number of values.
+- `lineCap`: One of the following pre-defined string values: `"round"`, `"butt"` or `"square"`. These values have the same meaning as those of [the `stroke-linecap` attribute in SVG](https://www.w3.org/TR/SVG11/painting.html#StrokeLinecapProperty).
 
 <aside class="example" title="Object stroke style example">
 
 ```json
 {
   "alert-border-style": {
-    "type": "stroke-style",
+    "type": "strokeStyle",
     "value": {
-      "dash-array": ["0.5rem", "0.25rem"],
-      "line-cap": "round"
+      "dashArray": ["0.5rem", "0.25rem"],
+      "lineCap": "round"
     }
   }
 }
@@ -155,10 +155,10 @@ Object stroke style values MUST have the following properties:
 ```json
 {
   "notification-border-style": {
-    "type": "stroke-style",
+    "type": "strokeStyle",
     "value": {
-      "dash-array": ["{dash-length-medium}", "0.25rem"],
-      "line-cap": "butt"
+      "dashArray": ["{dash-length-medium}", "0.25rem"],
+      "lineCap": "butt"
     }
   },
 
@@ -173,9 +173,9 @@ Object stroke style values MUST have the following properties:
 
 ### Fallbacks
 
-The string and object values are mutually exclusive means of expressing stroke styles. For example, some of the string values like `inset` or `groove` cannot be expressed in terms of a `dash-array` and `line-cap` as they require some implementation-specific means of lightening or darkening the _color_ for portions of a border or outline. Conversely, a precisely defined combination of `dash-array` and `line-cap` sub-values is not guaranteed to produce the same visual result as the `dashed` or `dotted` keywords as they are implementation-specific.
+The string and object values are mutually exclusive means of expressing stroke styles. For example, some of the string values like `inset` or `groove` cannot be expressed in terms of a `dashArray` and `lineCap` as they require some implementation-specific means of lightening or darkening the _color_ for portions of a border or outline. Conversely, a precisely defined combination of `dashArray` and `lineCap` sub-values is not guaranteed to produce the same visual result as the `dashed` or `dotted` keywords as they are implementation-specific.
 
-Furthermore, some tools and platforms may not support the full range of stroke styles that design tokens of this type can represent. When displaying or exporting a `stroke-style` token whose value they don't natively support, they should therefore fallback to the closest approximation that they do support.
+Furthermore, some tools and platforms may not support the full range of stroke styles that design tokens of this type can represent. When displaying or exporting a `strokeStyle` token whose value they don't natively support, they should therefore fallback to the closest approximation that they do support.
 
 The specifics of how a "closest approximation" is chosen are implementation-specific. However, the following examples illustrate what fallbacks tools MAY use in some scenarios.
 
@@ -199,11 +199,11 @@ Some design tools like Figma don't support inset, outset or double style lines. 
 
 ## Border
 
-Represents a border style. The type property must be set to the string “border”. The value must be an object with the following properties:
+Represents a border style. The `type` property MUST be set to the string `border`. The value MUST be an object with the following properties:
 
-- `color`: The color of the border. The value of this property must be a valid [color value](#color) or a reference to a color token.
-- `width`: The width or thickness of the border. The value of this property must be a valid [dimension value](#dimension) or a reference to a dimension token.
-- `style`: The border's style. The value of this property must be a valid [stroke style value](#stroke-style) or a reference to a stroke style token.
+- `color`: The color of the border. The value of this property MUST be a valid [color value](#color) or a reference to a color token.
+- `width`: The width or thickness of the border. The value of this property MUST be a valid [dimension value](#dimension) or a reference to a dimension token.
+- `style`: The border's style. The value of this property MUST be a valid [stroke style value](#stroke-style) or a reference to a stroke style token.
 
 <aside class="example" title="Border composite token examples">
 
@@ -224,8 +224,8 @@ Represents a border style. The type property must be set to the string “border
         "color": "{color.focusring}",
         "width": "1px",
         "style": {
-          "dash-array": ["0.5rem", "0.25rem"],
-          "line-cap": "round"
+          "dashArray": ["0.5rem", "0.25rem"],
+          "lineCap": "round"
         }
       }
     }
@@ -241,11 +241,11 @@ Represents a border style. The type property must be set to the string “border
 
 ## Transition
 
-Represents a animated transition between two states. The type property must be set to the string "transition". The value must be an object with the following properties:
+Represents a animated transition between two states. The `type` property MUST be set to the string `transition`. The value MUST be an object with the following properties:
 
-- `duration`: The duration of the transition. The value of this property must be a valid [duration](#duration) value or a reference to a duration token.
-- `delay`: The time to wait before the transition begins. The value of this property must be a valid [duration](#duration) value or a reference to a duration token.
-- `timing-function`: The color of the shadow. The value of this property must be a valid [cubic bézier](#cubic-bezier) value or a reference to a cubic bézier token.
+- `duration`: The duration of the transition. The value of this property MUST be a valid [duration](#duration) value or a reference to a duration token.
+- `delay`: The time to wait before the transition begins. The value of this property MUST be a valid [duration](#duration) value or a reference to a duration token.
+- `timingFunction`: The color of the shadow. The value of this property MUST be a valid [cubic bézier](#cubic-bezier) value or a reference to a cubic bézier token.
 
 <aside class="example" title="Transition composite token examples">
 
@@ -257,7 +257,7 @@ Represents a animated transition between two states. The type property must be s
       "value": {
         "duration": "200ms",
         "delay": "0ms",
-        "timing-function": [0.5, 0, 1, 1]
+        "timingFunction": [0.5, 0, 1, 1]
       }
     }
   }
@@ -272,13 +272,13 @@ Represents a animated transition between two states. The type property must be s
 
 ## Shadow
 
-Represents a shadow style. The type property must be set to the string “shadow”. The value must be an object with the following properties:
+Represents a shadow style. The `type` property MUST be set to the string `shadow`. The value must be an object with the following properties:
 
-- `color`: The color of the shadow. The value of this property must be a valid [color value](#color) or a reference to a color token.
-- `offset-x`: The horizontal offset that shadow has from the element it is applied to. The value of this property must be a valid [dimension value](#dimension) or a reference to a dimension token.
-- `offset-y`: The vertical offset that shadow has from the element it is applied to. The value of this property must be a valid [dimension value](#dimension) or a reference to a dimension token.
-- `blur`: The blur radius that is applied to the shadow. The value of this property must be a valid [dimension value](#dimension) or a reference to a dimension token.
-- `spread`: The amount by which to expand or contract the shadow. The value of this property must be a valid [dimension value](#dimension) or a reference to a dimension token.
+- `color`: The color of the shadow. The value of this property MUST be a valid [color value](#color) or a reference to a color token.
+- `offsetX`: The horizontal offset that shadow has from the element it is applied to. The value of this property MUST be a valid [dimension value](#dimension) or a reference to a dimension token.
+- `offsetY`: The vertical offset that shadow has from the element it is applied to. The value of this property MUST be a valid [dimension value](#dimension) or a reference to a dimension token.
+- `blur`: The blur radius that is applied to the shadow. The value of this property MUST be a valid [dimension value](#dimension) or a reference to a dimension token.
+- `spread`: The amount by which to expand or contract the shadow. The value of this property MUST be a valid [dimension value](#dimension) or a reference to a dimension token.
 
 <aside class="example" title="Shadow token example">
 
@@ -288,8 +288,8 @@ Represents a shadow style. The type property must be set to the string “shadow
     "type": "shadow",
     "value": {
       "color": "#00000088",
-      "offset-x": "0.5rem",
-      "offset-y": "0.5rem",
+      "offsetX": "0.5rem",
+      "offsetY": "0.5rem",
       "blur": "1.5rem",
       "spread": "0rem"
     }
@@ -305,10 +305,10 @@ Represents a shadow style. The type property must be set to the string “shadow
 
 ## Gradient
 
-Represents a color gradient. The value must be an array of objects representing gradient stops that have the following structure:
+Represents a color gradient. The `type` property MUST be set to the string `gradient`. The value MUST be an array of objects representing gradient stops that have the following structure:
 
-- `color`: The color value at the stop's position on the gradient. The value of this property must be a valid [color value](#color) or a reference to a color token.
-- `position`: The position of the stop along the gradient's axis. The value of this property must be a valid number value or reference to a number token. The number values must be in the range [0, 1], where 0 represents the start position of the gradient's axis and 1 the end position. If a number value outside of that range is given, it MUST be considered as if it were clamped to the range [0, 1]. For example, a value of 42 should be treated as if it were 1, i.e. the end position of the gradient axis. Similarly, a value of -99 should be treated as if it were 0, i.e. the start position of the gradient axis.
+- `color`: The color value at the stop's position on the gradient. The value of this property MUST be a valid [color value](#color) or a reference to a color token.
+- `position`: The position of the stop along the gradient's axis. The value of this property MUST be a valid number value or reference to a number token. The number values must be in the range [0, 1], where 0 represents the start position of the gradient's axis and 1 the end position. If a number value outside of that range is given, it MUST be considered as if it were clamped to the range [0, 1]. For example, a value of 42 should be treated as if it were 1, i.e. the end position of the gradient axis. Similarly, a value of -99 should be treated as if it were 0, i.e. the start position of the gradient axis.
 
 If there are no stops at the very beginning or end of the gradient axis (i.e. with `position` 0 or 1, respectively), then the color from the stop closest to each end should be extended to that end of the axis.
 
@@ -409,13 +409,13 @@ Describes a color token called "brand-primary", which is referenced as the mid-p
 
 ## Typography
 
-Represents a typographic style. The type property must be set to the string “typography”. The value must be an object with the following properties:
+Represents a typographic style. The `type` property MUST be set to the string `typography`. The value MUST be an object with the following properties:
 
-- `fontFamily`: The typography's font. The value of this property must be a valid [fontFamily value](#font-family) or a reference to a font family token.
-- `fontSize`: The size of the typography. The value of this property must be a valid [dimension value](#dimension) or a reference to a dimension token.
-- `fontWeight`: The weight of the typography. The value of this property must be a valid [font weight](#font-weight) or a reference to a font weight token.
-- `letterSpacing`: The horizontal spacing between characters. The value of this property must be a valid [dimension value](#dimension) or a reference to a dimension token.
-- `lineHeight`: The vertical spacing between lines of typography. The value of this property must be a valid JSON string or a reference to a string token.
+- `fontFamily`: The typography's font. The value of this property MUST be a valid [font family value](#font-family) or a reference to a font family token.
+- `fontSize`: The size of the typography. The value of this property MUST be a valid [dimension value](#dimension) or a reference to a dimension token.
+- `fontWeight`: The weight of the typography. The value of this property MUST be a valid [font weight](#font-weight) or a reference to a font weight token.
+- `letterSpacing`: The horizontal spacing between characters. The value of this property MUST be a valid [dimension value](#dimension) or a reference to a dimension token.
+- `lineHeight`: The vertical spacing between lines of typography. The value of this property MUST be a valid JSON string or a reference to a string token.
 
 <aside class="example" title="Typography composite token examples">
 
@@ -450,6 +450,6 @@ Represents a typographic style. The type property must be set to the string “t
 
 <div class="issue" data-number="102" title="Typography type feedback">
 
-Is the current specification for typography styles fit for purpose? [Should the `lineHeight` sub-value use a number value, dimension or a new line-height type](https://github.com/design-tokens/community-group/pull/86#discussion_r768137006)?
+Is the current specification for typography styles fit for purpose? [Should the `lineHeight` sub-value use a number value, dimension or a new lineHeight type](https://github.com/design-tokens/community-group/pull/86#discussion_r768137006)?
 
 </div>

--- a/technical-reports/format/composite-types.md
+++ b/technical-reports/format/composite-types.md
@@ -9,15 +9,15 @@ Specifically, a composite type has the following characteristics:
 - Its value is an object or array, potentially containing nested objects or arrays, following a pre-defined structure where the properties of the (nested) object(s) or the elements of the (nested) arrays are sub-values.
 - Sub-values may be explicit values (e.g. `"#ff0000"`) or references to other design tokens that have sub-value's type (e.g. `"{some.other.token}"`).
 
-A design token whose type happens to be a composite type is sometimes also called a composite (design) token. Besides their type, there is nothing special about composite tokens. They can have all the other additional properties like [description](#description) or [extensions](#extensions). They can also be referenced by other design tokens.
+A design token whose type happens to be a composite type is sometimes also called a composite (design) token. Besides their type, there is nothing special about composite tokens. They can have all the other additional properties like [`$description`](#description) or [`$extensions`](#extensions). They can also be referenced by other design tokens.
 
 <aside class="example" title="Composite token example">
 
 ```json
 {
   "shadow-token": {
-    "type": "shadow",
-    "value": {
+    "$type": "shadow",
+    "$value": {
       "color": "#00000088",
       "offsetX": "0.5rem",
       "offsetY": "0.5rem",
@@ -36,23 +36,23 @@ A design token whose type happens to be a composite type is sometimes also calle
 {
   "space": {
     "small": {
-      "type": "dimension",
-      "value": "0.5rem"
+      "$type": "dimension",
+      "$value": "0.5rem"
     }
   },
 
   "color": {
     "shadow-050": {
-      "type": "color",
-      "value": "#00000088"
+      "$type": "color",
+      "$value": "#00000088"
     }
   },
 
   "shadow": {
     "medium": {
-      "type": "shadow",
-      "description": "A composite token where some sub-values are references to tokens that have the correct type and others are explicit values",
-      "value": {
+      "$type": "shadow",
+      "$description": "A composite token where some sub-values are references to tokens that have the correct type and others are explicit values",
+      "$value": {
         "color": "{color.shadow-050}",
         "offsetX": "{space.small}",
         "offsetY": "{space.small}",
@@ -65,8 +65,8 @@ A design token whose type happens to be a composite type is sometimes also calle
   "component": {
     "card": {
       "box-shadow": {
-        "description": "This token is an alias for the composite token {shadow.medium}",
-        "value": "{shadow.medium}"
+        "$description": "This token is an alias for the composite token {shadow.medium}",
+        "$value": "{shadow.medium}"
       }
     }
   }
@@ -90,7 +90,7 @@ At first glance, groups and composite tokens might look very similar. However, t
 
 ## Stroke style
 
-Represents the style applied to lines or borders. The `type` property MUST be set to the string `strokeStyle`. The value MUST be either:
+Represents the style applied to lines or borders. The `$type` property MUST be set to the string `strokeStyle`. The value MUST be either:
 
 - a string value as defined in the corresponding section below, or
 - an object value as defined in the corresponding section below
@@ -119,8 +119,8 @@ These values have the same meaning as the equivalent ["line style" values in CSS
 ```json
 {
   "focus-ring-style": {
-    "type": "strokeStyle",
-    "value": "dashed"
+    "$type": "strokeStyle",
+    "$value": "dashed"
   }
 }
 ```
@@ -139,8 +139,8 @@ Object stroke style values MUST have the following properties:
 ```json
 {
   "alert-border-style": {
-    "type": "strokeStyle",
-    "value": {
+    "$type": "strokeStyle",
+    "$value": {
       "dashArray": ["0.5rem", "0.25rem"],
       "lineCap": "round"
     }
@@ -155,16 +155,16 @@ Object stroke style values MUST have the following properties:
 ```json
 {
   "notification-border-style": {
-    "type": "strokeStyle",
-    "value": {
+    "$type": "strokeStyle",
+    "$value": {
       "dashArray": ["{dash-length-medium}", "0.25rem"],
       "lineCap": "butt"
     }
   },
 
   "dash-length-medium": {
-    "type": "dimension",
-    "value": "10px"
+    "$type": "dimension",
+    "$value": "10px"
   }
 }
 ```
@@ -199,7 +199,7 @@ Some design tools like Figma don't support inset, outset or double style lines. 
 
 ## Border
 
-Represents a border style. The `type` property MUST be set to the string `border`. The value MUST be an object with the following properties:
+Represents a border style. The `$type` property MUST be set to the string `border`. The value MUST be an object with the following properties:
 
 - `color`: The color of the border. The value of this property MUST be a valid [color value](#color) or a reference to a color token.
 - `width`: The width or thickness of the border. The value of this property MUST be a valid [dimension value](#dimension) or a reference to a dimension token.
@@ -211,16 +211,16 @@ Represents a border style. The `type` property MUST be set to the string `border
 {
   "border": {
     "heavy": {
-      "type": "border",
-      "value": {
+      "$type": "border",
+      "$value": {
         "color": "#36363600",
         "width": "3px",
         "style": "solid"
       }
     },
     "focusring": {
-      "type": "border",
-      "value": {
+      "$type": "border",
+      "$value": {
         "color": "{color.focusring}",
         "width": "1px",
         "style": {
@@ -241,7 +241,7 @@ Represents a border style. The `type` property MUST be set to the string `border
 
 ## Transition
 
-Represents a animated transition between two states. The `type` property MUST be set to the string `transition`. The value MUST be an object with the following properties:
+Represents a animated transition between two states. The `$type` property MUST be set to the string `transition`. The value MUST be an object with the following properties:
 
 - `duration`: The duration of the transition. The value of this property MUST be a valid [duration](#duration) value or a reference to a duration token.
 - `delay`: The time to wait before the transition begins. The value of this property MUST be a valid [duration](#duration) value or a reference to a duration token.
@@ -253,8 +253,8 @@ Represents a animated transition between two states. The `type` property MUST be
 {
   "transition": {
     "emphasis": {
-      "type": "transition",
-      "value": {
+      "$type": "transition",
+      "$value": {
         "duration": "200ms",
         "delay": "0ms",
         "timingFunction": [0.5, 0, 1, 1]
@@ -272,7 +272,7 @@ Represents a animated transition between two states. The `type` property MUST be
 
 ## Shadow
 
-Represents a shadow style. The `type` property MUST be set to the string `shadow`. The value must be an object with the following properties:
+Represents a shadow style. The `$type` property MUST be set to the string `shadow`. The value must be an object with the following properties:
 
 - `color`: The color of the shadow. The value of this property MUST be a valid [color value](#color) or a reference to a color token.
 - `offsetX`: The horizontal offset that shadow has from the element it is applied to. The value of this property MUST be a valid [dimension value](#dimension) or a reference to a dimension token.
@@ -285,8 +285,8 @@ Represents a shadow style. The `type` property MUST be set to the string `shadow
 ```json
 {
   "shadow-token": {
-    "type": "shadow",
-    "value": {
+    "$type": "shadow",
+    "$value": {
       "color": "#00000088",
       "offsetX": "0.5rem",
       "offsetY": "0.5rem",
@@ -305,7 +305,7 @@ Represents a shadow style. The `type` property MUST be set to the string `shadow
 
 ## Gradient
 
-Represents a color gradient. The `type` property MUST be set to the string `gradient`. The value MUST be an array of objects representing gradient stops that have the following structure:
+Represents a color gradient. The `$type` property MUST be set to the string `gradient`. The value MUST be an array of objects representing gradient stops that have the following structure:
 
 - `color`: The color value at the stop's position on the gradient. The value of this property MUST be a valid [color value](#color) or a reference to a color token.
 - `position`: The position of the stop along the gradient's axis. The value of this property MUST be a valid number value or reference to a number token. The number values must be in the range [0, 1], where 0 represents the start position of the gradient's axis and 1 the end position. If a number value outside of that range is given, it MUST be considered as if it were clamped to the range [0, 1]. For example, a value of 42 should be treated as if it were 1, i.e. the end position of the gradient axis. Similarly, a value of -99 should be treated as if it were 0, i.e. the start position of the gradient axis.
@@ -317,8 +317,8 @@ If there are no stops at the very beginning or end of the gradient axis (i.e. wi
 ```json
 {
   "blue-to-red": {
-    "type": "gradient",
-    "value": [
+    "$type": "gradient",
+    "$value": [
       {
         "color": "#0000ff",
         "position": 0
@@ -343,8 +343,8 @@ Describes a gradient that goes from blue to red:
 ```json
 {
   "mostly-yellow": {
-    "type": "gradient",
-    "value": [
+    "$type": "gradient",
+    "$value": [
       {
         "color": "#ffff00",
         "position": 0.666
@@ -369,17 +369,17 @@ Describes a gradient that is solid yellow for the first 2/3 and then fades to re
 ```json
 {
   "brand-primary": {
-    "type": "color",
-    "value": "#99ff66"
+    "$type": "color",
+    "$value": "#99ff66"
   },
 
   "position-end": {
-    "value": 1
+    "$value": 1
   },
 
   "brand-in-the-middle": {
-    "type": "gradient",
-    "value": [
+    "$type": "gradient",
+    "$value": [
       {
         "color": "#000000",
         "position": 0
@@ -409,7 +409,7 @@ Describes a color token called "brand-primary", which is referenced as the mid-p
 
 ## Typography
 
-Represents a typographic style. The `type` property MUST be set to the string `typography`. The value MUST be an object with the following properties:
+Represents a typographic style. The `$type` property MUST be set to the string `typography`. The value MUST be an object with the following properties:
 
 - `fontFamily`: The typography's font. The value of this property MUST be a valid [font family value](#font-family) or a reference to a font family token.
 - `fontSize`: The size of the typography. The value of this property MUST be a valid [dimension value](#dimension) or a reference to a dimension token.
@@ -423,8 +423,8 @@ Represents a typographic style. The `type` property MUST be set to the string `t
 {
   "type styles": {
     "heading-level-1": {
-      "type": "typography",
-      "value": {
+      "$type": "typography",
+      "$value": {
         "fontFamily": "Roboto",
         "fontSize": "42px",
         "fontWeight": "700",
@@ -433,8 +433,8 @@ Represents a typographic style. The `type` property MUST be set to the string `t
       }
     },
     "microcopy": {
-      "type": "typography",
-      "value": {
+      "$type": "typography",
+      "$value": {
         "fontFamily": "{font.serif}",
         "fontSize": "{font.size.smallest}",
         "fontWeight": "{font.weight.normal}",

--- a/technical-reports/format/design-token.md
+++ b/technical-reports/format/design-token.md
@@ -14,7 +14,7 @@
 
 </aside>
 
-An object with a "**value**" property is a token. Thus, "value" is a reserved word in our spec, meaning you can't have a token whose name is "value". The parent object's key is the token name.
+An object with a **`value`** property is a token. Thus, `value` is a reserved word in our spec, meaning you can't have a token whose name is "value". The parent object's key is the token name.
 
 The example above therefore defines 1 design token with the following properties:
 
@@ -60,28 +60,17 @@ Due to the syntax used for [token aliases](#aliases-references) the following ch
 - `}` (right curly bracket)
 - `.` (period)
 
-<div class="issue" data-number="55" title="Object vs Array">
-
-The structure in the example above is a JSON object, an **unordered** set of name/value pairs.
-
-- Objects can't contain members with duplicate keys
-- Ordering of object members is not guaranteed (as per [RFC 7159](https://tools.ietf.org/html/rfc7159#section-4))
-
-Please raise concerns if these limitations create problems for implementers.
-
-</div>
-
 <div class="issue" data-number="61" title="Reserved words">
   Are there any reserved words that should not be allowed in token names?
 </div>
 
 ## Additional properties
 
-While "value" is the only required property for a token, a number of additional properties MAY be added:
+While `value` is the only required property for a token, a number of additional properties MAY be added:
 
 ## Description
 
-A plain text description explaining the token's purpose. Tools MAY use the description in various ways.
+An optional plain text description explaining the token's purpose. Tools MAY use the description in various ways.
 
 For example:
 
@@ -90,7 +79,7 @@ For example:
 - Design tools MAY display the description as a tooltip or alongside tokens wherever they can be selected
 - Export tools MAY render the description to a source code comment alongside the variable or constant they export.
 
-The **description** property MUST be a plain JSON string, for example:
+The **`description`** property MUST be a plain JSON string, for example:
 
 <aside class="example">
 
@@ -104,10 +93,6 @@ The **description** property MUST be a plain JSON string, for example:
 ```
 
 </aside>
-
-<div class="issue" data-number="62" title="Token descriptions optional or required">
-  Are token descriptions optional or required?
-</div>
 
 ## Type
 
@@ -145,7 +130,7 @@ For example:
 
 ## Extensions
 
-The **extensions** property is an object where tools MAY add proprietary, user-, team- or vendor-specific data to a design token. When doing so, each tool MUST use a vendor-specific key whose value MAY be any valid JSON data.
+The **`extensions`** property is an object where tools MAY add proprietary, user-, team- or vendor-specific data to a design token. When doing so, each tool MUST use a vendor-specific key whose value MAY be any valid JSON data.
 
 - The keys SHOULD be chosen such that they avoid the likelihood of a naming clash with another vendor's data. The [reverse domain name notation](https://en.wikipedia.org/wiki/Reverse_domain_name_notation) is recommended for this purpose.
 - Tools that process design token files MUST preserve any extension data they do not themselves understand. For example, if a design token contains extension data from tool A and the file containing that data is opened by tool B, then tool B MUST include the original tool A extension data whenever it saves a new design token file containing that token.

--- a/technical-reports/format/design-token.md
+++ b/technical-reports/format/design-token.md
@@ -109,7 +109,7 @@ The `$type` property can be set on different levels:
 - at the group level
 - at the token level
 
-The `$type` property MUST be a plain JSON string, whose value is `string`, `number`, `boolean`, `object`, `array`, `null` or one of the values specified in respective [type chapters](#types). THe value of `$type` is case-sensitive.
+The `$type` property MUST be a plain JSON string, whose value is `string`, `number`, `boolean`, `object`, `array`, `null` or one of the values specified in respective [type chapters](#types). The value of `$type` is case-sensitive.
 
 For example:
 

--- a/technical-reports/format/design-token.md
+++ b/technical-reports/format/design-token.md
@@ -7,14 +7,14 @@
 ```json
 {
   "token name": {
-    "value": "token value"
+    "$value": "token value"
   }
 }
 ```
 
 </aside>
 
-An object with a **`value`** property is a token. Thus, `value` is a reserved word in our spec, meaning you can't have a token whose name is "value". The parent object's key is the token name.
+An object with a **`$value`** property is a token. Thus, `$value` is a reserved word in our spec, meaning you can't have a token whose name is "$value". The parent object's key is the token name.
 
 The example above therefore defines 1 design token with the following properties:
 
@@ -29,8 +29,8 @@ Token names are case-sensitive, so the following example with 2 tokens in the sa
 
 ```json
 {
-  "font-size": { "value": "3rem" },
-  "FONT-SIZE": { "value": "16px" }
+  "font-size": { "$value": "3rem" },
+  "FONT-SIZE": { "$value": "16px" }
 }
 ```
 
@@ -54,23 +54,21 @@ Tools MAY display a warning when token names differ only by case.
 
 ### Character restrictions
 
-Due to the syntax used for [token aliases](#aliases-references) the following characters cannot be used in a token's **name** property or in a [token group](#groups-0) name:
+All properties defined by this format are prefixed with the dollar sign (`$`). This convention will also be used for any new properties introduced by future versions of this spec. Therefore, token and [group](#groups-0)] names MUST NOT begin with the `$` character.
+
+Furthermore, due to the syntax used for [token aliases](#aliases-references) the following characters MUST NOT be used anywhere in a token or group name:
 
 - `{` (left curly bracket)
 - `}` (right curly bracket)
 - `.` (period)
 
-<div class="issue" data-number="61" title="Reserved words">
-  Are there any reserved words that should not be allowed in token names?
-</div>
-
 ## Additional properties
 
-While `value` is the only required property for a token, a number of additional properties MAY be added:
+While `$value` is the only required property for a token, a number of additional properties MAY be added:
 
 ## Description
 
-An optional plain text description explaining the token's purpose. Tools MAY use the description in various ways.
+A plain text description explaining the token's purpose can be provided via the optional `$description` property. Tools MAY use the description in various ways.
 
 For example:
 
@@ -79,15 +77,15 @@ For example:
 - Design tools MAY display the description as a tooltip or alongside tokens wherever they can be selected
 - Export tools MAY render the description to a source code comment alongside the variable or constant they export.
 
-The **`description`** property MUST be a plain JSON string, for example:
+The value of the `$description` property MUST be a plain JSON string, for example:
 
 <aside class="example">
 
 ```json
 {
   "Button background": {
-    "value": "#777777",
-    "description": "The background color for buttons in their normal state."
+    "$value": "#777777",
+    "$description": "The background color for buttons in their normal state."
   }
 }
 ```
@@ -98,20 +96,20 @@ The **`description`** property MUST be a plain JSON string, for example:
 
 Design tokens always have an unambiguous type, so that tools can reliably interpret their value.
 
-If a token's type is not explicitly specified via the `type` property, then the token's type MUST be determined as follows:
+A token's type can be specified by the optional `$type` property. If the `$type` property is not set on a token, then the token's type MUST be determined as follows:
 
 - If the token's value is a reference, then its type is the type of the token being referenced.
-- Otherwise, if any of the token's parent groups have a `type` property, then the token's type is inherited from the closest parent group with a `type` property.
+- Otherwise, if any of the token's parent groups have a `$type` property, then the token's type is inherited from the closest parent group with a `$type` property.
 - Otherwise, the token's type is whichever of the basic JSON types (`string`, `number`, `boolean`, `object`, `array` or `null`) its value is.
 
 Tools MUST NOT attempt to guess the type of a token by inspecting the contents of its value.
 
-The `type` property can be set on different levels:
+The `$type` property can be set on different levels:
 
 - at the group level
 - at the token level
 
-The `type` property MUST be a plain JSON string, whose value is one of the [types](#types) defined in this specification.
+The `$type` property MUST be a plain JSON string, whose value is `string`, `number`, `boolean`, `object`, `array`, `null` or one of the values specified in respective [type chapters](#types). THe value of `$type` is case-sensitive.
 
 For example:
 
@@ -120,8 +118,8 @@ For example:
 ```json
 {
   "Button background": {
-    "value": "#777777",
-    "type": "color"
+    "$value": "#777777",
+    "$type": "color"
   }
 }
 ```
@@ -130,7 +128,7 @@ For example:
 
 ## Extensions
 
-The **`extensions`** property is an object where tools MAY add proprietary, user-, team- or vendor-specific data to a design token. When doing so, each tool MUST use a vendor-specific key whose value MAY be any valid JSON data.
+The optional **`$extensions`** property is an object where tools MAY add proprietary, user-, team- or vendor-specific data to a design token. When doing so, each tool MUST use a vendor-specific key whose value MAY be any valid JSON data.
 
 - The keys SHOULD be chosen such that they avoid the likelihood of a naming clash with another vendor's data. The [reverse domain name notation](https://en.wikipedia.org/wiki/Reverse_domain_name_notation) is recommended for this purpose.
 - Tools that process design token files MUST preserve any extension data they do not themselves understand. For example, if a design token contains extension data from tool A and the file containing that data is opened by tool B, then tool B MUST include the original tool A extension data whenever it saves a new design token file containing that token.
@@ -140,8 +138,8 @@ The **`extensions`** property is an object where tools MAY add proprietary, user
 ```json
 {
   "Button background": {
-    "value": "#777777",
-    "extensions": {
+    "$value": "#777777",
+    "$extensions": {
       "org.example.tool-a": 42,
       "org.example.tool-b": {
         "turn-up-to-11": true

--- a/technical-reports/format/groups.md
+++ b/technical-reports/format/groups.md
@@ -7,18 +7,18 @@ A file MAY contain many tokens and they MAY be nested arbitrarily in groups like
 ```json
 {
   "token uno": {
-    "value": "token value 1"
+    "$value": "token value 1"
   },
   "token group": {
     "token dos": {
-      "value": "token value 2"
+      "$value": "token value 2"
     },
     "nested token group": {
       "token tres": {
-        "value": "token value 3"
+        "$value": "token value 3"
       },
       "Token cuatro": {
-        "value": "token value 4"
+        "$value": "token value 4"
       }
     }
   }
@@ -60,7 +60,7 @@ The names of items in a group are case sensitive. As per the guidance in the [de
 
 ### Description
 
-Groups MAY include an optional `description` property.
+Groups MAY include an optional `$description` property, whose value MUST be a plain JSON string. Its purpose is to describe the group itself.
 
 For example:
 
@@ -69,14 +69,14 @@ For example:
 ```json
 {
   "brand": {
-    "description": "Design tokens from our brand guidelines",
+    "$description": "Design tokens from our brand guidelines",
     "color": {
-      "description": "Our brand's primary color palette",
+      "$description": "Our brand's primary color palette",
       "acid green": {
-        "value": "#00ff66"
+        "$value": "#00ff66"
       },
       "hot pink": {
-        "value": "#dd22cc"
+        "$value": "#dd22cc"
       }
     }
   }
@@ -99,9 +99,9 @@ Groups may support additional properties like type and description. Should other
 
 ### Type
 
-Groups MAY include an optional `type` property so a type property does not need to be manually added to every token. [See supported "Types"](#types) for more information.
+Groups MAY include an optional `$type` property so a type property does not need to be manually added to every token. [See supported "Types"](#types) for more information.
 
-If a group has a `type` property it acts as a default type for any tokens within the group, including ones in nested groups, that do not explicity declare a type via their own `type` property. For the full set of rules by which a design token's type is determined, please refer to the [design token type property chapter](#type-0).
+If a group has a `$type` property it acts as a default type for any tokens within the group, including ones in nested groups, that do not explicity declare a type via their own `$type` property. For the full set of rules by which a design token's type is determined, please refer to the [design token type property chapter](#type-0).
 
 For example:
 
@@ -110,14 +110,13 @@ For example:
 ```json
 {
   "brand": {
-    "type": "color",
+    "$type": "color",
     "color": {
-      "description": "Our brand's primary color palette",
       "acid green": {
-        "value": "#00ff66"
+        "$value": "#00ff66"
       },
       "hot pink": {
-        "value": "#dd22cc"
+        "$value": "#dd22cc"
       }
     }
   }
@@ -140,19 +139,21 @@ For example:
 {
   "brand": {
     "color": {
+      "$type": "color",
       "acid green": {
-        "value": "#00ff66"
+        "$value": "#00ff66"
       },
       "hot pink": {
-        "value": "#dd22cc"
+        "$value": "#dd22cc"
       }
     },
     "typeface": {
+      "$type": "fontFamily",
       "primary": {
-        "value": "Comic Sans MS"
+        "$value": "Comic Sans MS"
       },
       "secondary": {
-        "value": "Times New Roman"
+        "$value": "Times New Roman"
       }
     }
   }
@@ -168,16 +169,20 @@ For example:
 ```json
 {
   "brand-color-acid-green": {
-    "value": "#00ff66"
+    "$value": "#00ff66",
+    "$type": "color"
   },
   "brand-color-hot-pink": {
-    "value": "#dd22cc"
+    "$value": "#dd22cc",
+    "$type": "color"
   },
   "brand-typeface-primary": {
-    "value": "Comic Sans MS"
+    "$value": "Comic Sans MS",
+    "$type": "fontFamily"
   },
   "brand-typeface-secondary": {
-    "value": "Times New Roman"
+    "$value": "Times New Roman",
+    "$type": "fontFamily"
   }
 }
 ```
@@ -202,19 +207,21 @@ For example, a [translation tool](#translation-tool) like [Style Dictionary](htt
 {
   "brand": {
     "color": {
+      "$type": "color",
       "acid green": {
-        "value": "#00ff66"
+        "$value": "#00ff66"
       },
       "hot pink": {
-        "value": "#dd22cc"
+        "$value": "#dd22cc"
       }
     },
     "typeface": {
+      "$type": "fontFamily",
       "primary": {
-        "value": "Comic Sans MS"
+        "$value": "Comic Sans MS"
       },
       "secondary": {
-        "value": "Times New Roman"
+        "$value": "Times New Roman"
       }
     }
   }

--- a/technical-reports/format/types.md
+++ b/technical-reports/format/types.md
@@ -11,15 +11,15 @@ Since design token files are JSON files, all the basic JSON types are available:
 - Boolean
 - Null
 
-Additionally, this spec defines a number of more design-focused types. To set a token to one of these types, it MUST have a type property specifying the chosen type. Furthermore, that token's value MUST then follow rules and syntax for the chosen type as defined by this spec.
+Additionally, this spec defines a number of more design-focused types. To set a token to one of these types, it MUST either have a `$type` property specifying the chosen type, inherit a type from one of its parent groups, or be an alias of a token that has the desired type. Furthermore, that token's value MUST then follow rules and syntax for the chosen type as defined by this spec.
 
-If the `type` property is absent, tools MUST treat values as one of the basic JSON types and not attempt to infer any other type from the value.
+If no explicit type has been set for a token, tools MUST treat values as one of the basic JSON types and not attempt to infer any other type from the value.
 
-If a `type` is set, but the value does not match the expected syntax then that token is invalid and an appropriate error SHOULD be displayed to the user. To put it another way, the `type` property is a declaration of what kind of values are permissible for the token. (This is similar to typing in programming languages like Java or TypeScript, where a value not compatible with the declared type causes a compilation error).
+If an explicit type is set, but the value does not match the expected syntax then that token is invalid and an appropriate error SHOULD be displayed to the user. To put it another way, the `$type` property is a declaration of what kind of values are permissible for the token. (This is similar to typing in programming languages like Java or TypeScript, where a value not compatible with the declared type causes a compilation error).
 
 ## Color
 
-Represents a 24bit RGB or 24+8bit RGBA color in the sRGB color space. The `type` property MUST be set to the string `color`. The value MUST be a string containing a hex triplet/quartet including the preceding # character. To support other color spaces, such as HSL, export tools SHOULD convert color tokens to the equivalent value as needed.
+Represents a 24bit RGB or 24+8bit RGBA color in the sRGB color space. The `$type` property MUST be set to the string `color`. The value MUST be a string containing a hex triplet/quartet including the preceding `#` character. To support other color spaces, such as HSL, export tools SHOULD convert color tokens to the equivalent value as needed.
 
 For example, initially the color tokens MAY be defined as such:
 
@@ -28,12 +28,12 @@ For example, initially the color tokens MAY be defined as such:
 ```json
 {
   "Majestic magenta": {
-    "value": "#ff00ff",
-    "type": "color"
+    "$value": "#ff00ff",
+    "$ype": "color"
   },
   "Translucent shadow": {
-    "value": "#00000088",
-    "type": "color"
+    "$value": "#00000088",
+    "$type": "color"
   }
 }
 ```
@@ -58,7 +58,7 @@ $translucent-shadow: hsla(300, 100%, 50%, 0.5);
 
 ## Dimension
 
-Represents an amount of distance in a single dimension in the UI, such as a position, width, height, radius, or thickness. The `type` property MUST be set to the string `dimension`. The value must be a string containing a number (either integer or floating-point) followed by either a "px" or "rem" unit (future spec iterations may add support for additional units).
+Represents an amount of distance in a single dimension in the UI, such as a position, width, height, radius, or thickness. The `$type` property MUST be set to the string `dimension`. The value must be a string containing a number (either integer or floating-point) followed by either a "px" or "rem" unit (future spec iterations may add support for additional units).
 
 For example:
 
@@ -67,8 +67,8 @@ For example:
 ```json
 {
   "spacingStack1X": {
-    "value": "0.25rem",
-    "type": "dimension"
+    "$value": "0.25rem",
+    "$type": "dimension"
   }
 }
 ```
@@ -88,7 +88,7 @@ A naive approach like the one below may be appropriate for the first stage of th
 
 </div>
 
-Represents a font name or an array of font names (ordered from most to least preferred). The `type` property MUST be set to the string `fontFamily`. The value MUST either be a string value containing a single font name or an array of strings, each being a single font name.
+Represents a font name or an array of font names (ordered from most to least preferred). The `$type` property MUST be set to the string `fontFamily`. The value MUST either be a string value containing a single font name or an array of strings, each being a single font name.
 
 For example:
 
@@ -97,12 +97,12 @@ For example:
 ```json
 {
   "Primary font": {
-    "value": "Comic Sans MS",
-    "type": "fontFamily"
+    "$value": "Comic Sans MS",
+    "$type": "fontFamily"
   },
   "Body font": {
-    "value": ["Helvetica", "Arial"],
-    "type": "fontFamily"
+    "$value": ["Helvetica", "Arial"],
+    "$type": "fontFamily"
   }
 }
 ```
@@ -111,7 +111,7 @@ For example:
 
 ## Font weight
 
-Represents a font weight. The `type` property MUST be set to the string `fontWeight`. The value must either be a number value in the range [1, 1000] or one of the pre-defined string values defined in the table below.
+Represents a font weight. The `$type` property MUST be set to the string `fontWeight`. The value must either be a number value in the range [1, 1000] or one of the pre-defined string values defined in the table below.
 
 Lower numbers represent lighter weights, and higher numbers represent thicker weights, as per the [OpenType `wght` tag specification](https://docs.microsoft.com/en-us/typography/opentype/spec/dvaraxistag_wght). The pre-defined string values are aliases for specific numeric values. For example `100`, `"thin"` and `"hairline"` are all the exact same value.
 
@@ -137,12 +137,12 @@ Example:
 ```json
 {
   "font-weight-default": {
-    "value": 350,
-    "type": "fontWeight"
+    "$value": 350,
+    "$type": "fontWeight"
   },
   "font-weight-thick": {
-    "value": "extra-bold",
-    "type": "fontWeight"
+    "$value": "extra-bold",
+    "$type": "fontWeight"
   }
 }
 ```
@@ -151,7 +151,7 @@ Example:
 
 ## Duration
 
-Represents the length of time in milliseconds an animation or animation cycle takes to complete, such as 200 milliseconds. The `type` property MUST be set to the string `duration`. The value MUST be a string containing a number (either integer or floating-point) followed by an "ms" unit. A millisecond is a unit of time equal to one thousandth of a second.
+Represents the length of time in milliseconds an animation or animation cycle takes to complete, such as 200 milliseconds. The `$type` property MUST be set to the string `duration`. The value MUST be a string containing a number (either integer or floating-point) followed by an "ms" unit. A millisecond is a unit of time equal to one thousandth of a second.
 
 For example:
 
@@ -160,12 +160,12 @@ For example:
 ```json
 {
   "Duration-100": {
-    "value": "100ms",
-    "type": "duration"
+    "$value": "100ms",
+    "$type": "duration"
   },
   "Duration-200": {
-    "value": "200ms",
-    "type": "duration"
+    "$value": "200ms",
+    "$type": "duration"
   }
 }
 ```
@@ -174,7 +174,7 @@ For example:
 
 ## Cubic Bézier
 
-Represents how the value of an animated property progresses towards completion over the duration of an animation, effectively creating visual effects such as acceleration, deceleration, and bounce. The `type` property MUST be set to the string `cubicBezier`. The value MUST be an array containing four numbers. These numbers represent two points (P1, P2) with one x coordinate and one y coordinate each [P1x, P1y, P2x, P2y]. The y coordinates of P1 and P2 can be any real number in the range [-∞, ∞], but the x coordinates are restricted to the range [0, 1].
+Represents how the value of an animated property progresses towards completion over the duration of an animation, effectively creating visual effects such as acceleration, deceleration, and bounce. The `$type` property MUST be set to the string `cubicBezier`. The value MUST be an array containing four numbers. These numbers represent two points (P1, P2) with one x coordinate and one y coordinate each [P1x, P1y, P2x, P2y]. The y coordinates of P1 and P2 can be any real number in the range [-∞, ∞], but the x coordinates are restricted to the range [0, 1].
 
 For example:
 
@@ -183,12 +183,12 @@ For example:
 ```json
 {
   "Accelerate": {
-    "value": [0.5, 0, 1, 1],
-    "type": "cubicBezier"
+    "$value": [0.5, 0, 1, 1],
+    "$type": "cubicBezier"
   },
   "Decelerate": {
-    "value": [0, 0, 0.5, 1],
-    "type": "cubicBezier"
+    "$value": [0, 0, 0.5, 1],
+    "$type": "cubicBezier"
   }
 }
 ```

--- a/technical-reports/format/types.md
+++ b/technical-reports/format/types.md
@@ -19,7 +19,7 @@ If a `type` is set, but the value does not match the expected syntax then that t
 
 ## Color
 
-Represents a 24bit RGB or 24+8bit RGBA color in the sRGB color space. The `type` property MUST be set to the string "color". The value MUST be a string containing a hex triplet/quartet including the preceding # character. To support other color spaces, such as HSL, export tools SHOULD convert color tokens to the equivalent value as needed.
+Represents a 24bit RGB or 24+8bit RGBA color in the sRGB color space. The `type` property MUST be set to the string `color`. The value MUST be a string containing a hex triplet/quartet including the preceding # character. To support other color spaces, such as HSL, export tools SHOULD convert color tokens to the equivalent value as needed.
 
 For example, initially the color tokens MAY be defined as such:
 
@@ -58,7 +58,7 @@ $translucent-shadow: hsla(300, 100%, 50%, 0.5);
 
 ## Dimension
 
-Represents an amount of distance in a single dimension in the UI, such as a position, width, height, radius, or thickness. The `type` property must be set to the string "dimension". The value must be a string containing a number (either integer or floating-point) followed by either a "px" or "rem" unit (future spec iterations may add support for additional units).
+Represents an amount of distance in a single dimension in the UI, such as a position, width, height, radius, or thickness. The `type` property MUST be set to the string `dimension`. The value must be a string containing a number (either integer or floating-point) followed by either a "px" or "rem" unit (future spec iterations may add support for additional units).
 
 For example:
 
@@ -88,7 +88,7 @@ A naive approach like the one below may be appropriate for the first stage of th
 
 </div>
 
-Represents a font name or an array of font names (ordered from most to least preferred). The `type` property MUST be set to the string "fontFamily". The value MUST either be a string value containing a single font name or an array of strings, each being a single font name.
+Represents a font name or an array of font names (ordered from most to least preferred). The `type` property MUST be set to the string `fontFamily`. The value MUST either be a string value containing a single font name or an array of strings, each being a single font name.
 
 For example:
 
@@ -111,7 +111,7 @@ For example:
 
 ## Font weight
 
-Represents a font weight. The `type` property must be set to the string "font-weight". The value must either be a number value in the range [1, 1000] or one of the pre-defined string values defined in the table below.
+Represents a font weight. The `type` property MUST be set to the string `fontWeight`. The value must either be a number value in the range [1, 1000] or one of the pre-defined string values defined in the table below.
 
 Lower numbers represent lighter weights, and higher numbers represent thicker weights, as per the [OpenType `wght` tag specification](https://docs.microsoft.com/en-us/typography/opentype/spec/dvaraxistag_wght). The pre-defined string values are aliases for specific numeric values. For example `100`, `"thin"` and `"hairline"` are all the exact same value.
 
@@ -138,11 +138,11 @@ Example:
 {
   "font-weight-default": {
     "value": 350,
-    "type": "font-weight"
+    "type": "fontWeight"
   },
   "font-weight-thick": {
     "value": "extra-bold",
-    "type": "font-weight"
+    "type": "fontWeight"
   }
 }
 ```
@@ -151,7 +151,7 @@ Example:
 
 ## Duration
 
-Represents the length of time in milliseconds an animation or animation cycle takes to complete, such as 200 milliseconds. The `type` property MUST be set to the string "duration". The value MUST be a string containing a number (either integer or floating-point) followed by an "ms" unit. A millisecond is a unit of time equal to one thousandth of a second.
+Represents the length of time in milliseconds an animation or animation cycle takes to complete, such as 200 milliseconds. The `type` property MUST be set to the string `duration`. The value MUST be a string containing a number (either integer or floating-point) followed by an "ms" unit. A millisecond is a unit of time equal to one thousandth of a second.
 
 For example:
 
@@ -174,7 +174,7 @@ For example:
 
 ## Cubic Bézier
 
-Represents how the value of an animated property progresses towards completion over the duration of an animation, effectively creating visual effects such as acceleration, deceleration, and bounce. The `type` property MUST be set to the string "cubic-bezier". The value MUST be an array containing four numbers. These numbers represent two points (P1, P2) with one x coordinate and one y coordinate each [P1x, P1y, P2x, P2y]. The y coordinates of P1 and P2 can be any real number in the range [-∞, ∞], but the x coordinates are restricted to the range [0, 1].
+Represents how the value of an animated property progresses towards completion over the duration of an animation, effectively creating visual effects such as acceleration, deceleration, and bounce. The `type` property MUST be set to the string `cubicBezier`. The value MUST be an array containing four numbers. These numbers represent two points (P1, P2) with one x coordinate and one y coordinate each [P1x, P1y, P2x, P2y]. The y coordinates of P1 and P2 can be any real number in the range [-∞, ∞], but the x coordinates are restricted to the range [0, 1].
 
 For example:
 
@@ -184,11 +184,11 @@ For example:
 {
   "Accelerate": {
     "value": [0.5, 0, 1, 1],
-    "type": "cubic-bezier"
+    "type": "cubicBezier"
   },
   "Decelerate": {
     "value": [0, 0, 0.5, 1],
-    "type": "cubic-bezier"
+    "type": "cubicBezier"
   }
 }
 ```
@@ -205,6 +205,5 @@ Types still to be documented here are likely to include:
 - **Percentage/ratio:** e.g. for opacity values, relative dimensions, aspect ratios, etc.
   - Not 100% sure about this since these are really "just" numbers. An alternative might be that we expand the permitted syntax for the "number" type, so for example "1:2", "50%" and 0.5 are all equivalent. People can then use whichever syntax they like best for a given token.
 - **File:** for assets - might just be a relative file path / URL (or should we let people also express the mime-type?)
-- **Easing definitions:** for animation
 
 </section>


### PR DESCRIPTION
Makes the following changes required by #108:

* Changes format properties, type names and sub-value names to all use lower camel case for consistency
* Prefixes all format properties with `$`

It also:

* Removes references to issues that have been closed
* Makes some instances of "must" to "MUST" as they are required for interoperability
* Some minor formatting and wording tweaks