### PR TITLE
Add placeholder content for color module

### DIFF
--- a/.github/workflows/technical-reports.yml
+++ b/.github/workflows/technical-reports.yml
@@ -19,6 +19,8 @@ jobs:
             destination: index.html
           - source: technical-reports/format/index.html
             destination: format/index.html
+          - source: technical-reports/color/index.html
+            destination: color/index.html
     steps:
       - uses: actions/checkout@v2
       - uses: w3c/spec-prod@v2

--- a/technical-reports/color/color-type.md
+++ b/technical-reports/color/color-type.md
@@ -1,0 +1,22 @@
+# The color type
+
+Represents a 24bit RGB or 24+8bit RGBA color in the sRGB color space. The `$type` property MUST be set to the string `color`. The value MUST be a string containing a hex triplet/quartet including the preceding `#` character. To support other color spaces, such as HSL, export tools SHOULD convert color tokens to the equivalent value as needed.
+
+For example, initially the color tokens MAY be defined as such:
+
+<aside class="example">
+
+```json
+{
+  "Majestic magenta": {
+    "$value": "#ff00ff",
+    "$ype": "color"
+  },
+  "Translucent shadow": {
+    "$value": "#00000088",
+    "$type": "color"
+  }
+}
+```
+
+</aside>

--- a/technical-reports/color/index.html
+++ b/technical-reports/color/index.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Design Tokens Color Module</title>
+    <script
+      src="https://www.w3.org/Tools/respec/respec-w3c"
+      class="remove"
+      defer
+    ></script>
+    <script class="remove">
+      var respecConfig = {
+        specStatus: 'CG-DRAFT',
+        group: 'design-tokens',
+        latestVersion: null,
+        edDraftURI: null,
+        editors: [
+          { name: 'Adekunle Oduye', url: 'http://twitter.com/adekunleoduye' },
+          {
+            name: 'Ayesha Mazrana (Mazumdar)',
+            url: 'https://twitter.com/AyeshaKMaz',
+          },
+          { name: 'Kathleen McMahon', url: 'https://twitter.com/resource11' },
+        ],
+
+        github: {
+          repoURL: 'https://github.com/design-tokens/community-group',
+          branch: 'color',
+        },
+        tocIntroductory: true,
+      };
+    </script>
+    <style>
+      :root {
+        /* Remove watermark negatively impacting readability */
+        --unofficial-watermark: none !important;
+      }
+      .rfc2119 {
+        font-style: normal;
+        font-size: 0.875em;
+      }
+    </style>
+  </head>
+  <body>
+    <p class="copyright remove"></p>
+
+    <section id="abstract">
+      <p>
+        This document describes the technical specification for design token
+        color values and opacity.
+      </p>
+    </section>
+
+    <section id="sotd">
+      <p>
+        This is a snapshot of the editors' draft. It is provided for discussion
+        only and may change at any moment. Its publication here does not imply
+        endorsement of its contents by W3C or the Design Tokens W3C Community
+        Group Membership. Don't cite this document other than as work in
+        progress.
+      </p>
+      <p>This document has been published to facilitate Wide Review.</p>
+      <p>
+        This document was produced by the Design Tokens W3C Community Group, and
+        contributions to this draft are governed by
+        <a href="https://www.w3.org/community/about/process/cla">
+          Community Contributor License Agreement (CLA)</a
+        >, as specified by the
+        <a href="https://www.w3.org/community/about/process/#cgroups"
+          >W3C Community Group Process</a
+        >.
+      </p>
+    </section>
+
+    <section id="conformance"></section>
+
+    <section id="introduction">
+      <h1>Introduction</h1>
+
+      <p>
+        <em>This section is non normative</em>
+      </p>
+
+      <p>Work in progress.</p>
+    </section>
+
+    <section
+      data-include="./color-type.md"
+      data-include-format="markdown"
+    ></section>
+
+    <section class="appendix" id="issue-summary"></section>
+  </body>
+</html>


### PR DESCRIPTION
This is work in progress with placeholder content, so the Color module editors can start adding content.