### PR TITLE
Add definition references for 'Design tool' and 'Translation tool'

### DIFF
--- a/technical-reports/format/aliases.md
+++ b/technical-reports/format/aliases.md
@@ -30,7 +30,7 @@ For example:
 
 When a tool needs the actual value of a token it MUST resolve the reference - i.e. lookup the token being referenced and fetch its value. In the above example, the "alias name" token's value would resolve to 1234 because it references the token whose path is `{group name.token name}` which has the value 1234.
 
-Tools SHOULD preserve references and therefore only resolve them whenever the actual value needs to be retrieved. For instance, in a design tool, changes to the value of a token being referenced by aliases SHOULD be reflected wherever those aliases are being used.
+Tools SHOULD preserve references and therefore only resolve them whenever the actual value needs to be retrieved. For instance, in a [=design tool=], changes to the value of a token being referenced by aliases SHOULD be reflected wherever those aliases are being used.
 
 Aliases MAY reference other aliases. In this case, tools MUST follow each reference until they find a token with an explicit value. Circular references are not allowed. If a design token file contains circular references, then the value of all tokens in that chain is unknown and an appropriate error or warning message SHOULD be displayed to the user.
 

--- a/technical-reports/format/composite-types.md
+++ b/technical-reports/format/composite-types.md
@@ -86,7 +86,7 @@ At first glance, groups and composite tokens might look very similar. However, t
 - **Composite tokens** are individual design tokens whose values are made up of several sub-values.
   - Since they are design tokens, they can be referenced by other design tokens. This is not true for groups.
   - Their type must be one of the composite types defined in this specification. Therefore their names and types of their sub-values are pre-defined. Adding additional sub-values or setting values that don't have the correct type make the composite token invalid.
-  - Tools MAY provide specialised functionality for composite tokens. For example, a design tool may let the user pick from a list of all available shadow tokens when applying a drop shadow effect to an element.
+  - Tools MAY provide specialised functionality for composite tokens. For example, a [=design tool=] may let the user pick from a list of all available shadow tokens when applying a drop shadow effect to an element.
 
 ## Stroke style
 
@@ -193,7 +193,7 @@ CSS does not allow detailed control of the dash pattern or line caps on dashed b
 
 <aside class="example" title="Fallback for string stroke style">
 
-Some design tools like Figma don't support inset, outset or double style lines. When a user applies a `stroke-style` token with those values, such tools might therefore fallback to displaying a solid line instead.
+Some [=design tools=] like Figma don't support inset, outset or double style lines. When a user applies a `stroke-style` token with those values, such tools might therefore fallback to displaying a solid line instead.
 
 </aside>
 
@@ -236,7 +236,7 @@ Represents a border style. The `$type` property MUST be set to the string `borde
 </aside>
 
 <div class="issue" data-number="99" title="Border type feedback">
-  Is the current specification for borders fit for purpose? Does it need more sub-values to account for features like outset, border images, multiple borders, etc. that some platforms an design tools have?
+  Is the current specification for borders fit for purpose? Does it need more sub-values to account for features like outset, border images, multiple borders, etc. that some platforms and [=design tools=] have?
 </div>
 
 ## Transition

--- a/technical-reports/format/design-token.md
+++ b/technical-reports/format/design-token.md
@@ -74,7 +74,7 @@ For example:
 
 - Style guide generators MAY display the description text alongside a visual preview of the token
 - IDEs MAY display the description as a tooltip for auto-completion (similar to how API docs are displayed)
-- Design tools MAY display the description as a tooltip or alongside tokens wherever they can be selected
+- [=Design tools=] MAY display the description as a tooltip or alongside tokens wherever they can be selected
 - Export tools MAY render the description to a source code comment alongside the variable or constant they export.
 
 The value of the `$description` property MUST be a plain JSON string, for example:

--- a/technical-reports/format/groups.md
+++ b/technical-reports/format/groups.md
@@ -199,7 +199,7 @@ Tools that let users pick or edit tokens via a GUI MAY use the grouping structur
 
 Token names are not guaranteed to be unique within the same file. The same name can be used in different groups. Also, export tools MAY need to export design tokens in a uniquely identifiable way, such as variables in code. Export tools SHOULD therefore use design tokens' paths as these _are_ unique within a file.
 
-For example, a [translation tool](#translation-tool) like [Style Dictionary](https://amzn.github.io/style-dictionary/) might use the following design token file:
+For example, a [=translation tool=] like [Style Dictionary](https://amzn.github.io/style-dictionary/) might use the following design token file:
 
 <aside class="example">
 

--- a/technical-reports/format/index.html
+++ b/technical-reports/format/index.html
@@ -96,8 +96,9 @@
           shared values for design properties like colors and sizes.
         </li>
         <li>
-          Translation tools exist that can convert source design token data into
-          platform-specific source code that can directly be used by developers.
+          [=Translation tools=] exist that can convert source design token data
+          into platform-specific source code that can directly be used by
+          developers.
         </li>
         <li>
           Documentation tools can display design token names rather than the raw
@@ -113,7 +114,7 @@
       <ul>
         <li>
           Extracting design tokens from design files and feeding them into
-          translation tools to then be converted into platform-specific code
+          [=translation tools=] to then be converted into platform-specific code
         </li>
         <li>
           Maintaining a "single source of truth" for design tokens and

--- a/technical-reports/format/index.html
+++ b/technical-reports/format/index.html
@@ -92,7 +92,7 @@
       </p>
       <ul>
         <li>
-          Design tools have begun allowing designers to label and reference
+          [=Design tools=] have begun allowing designers to label and reference
           shared values for design properties like colors and sizes.
         </li>
         <li>

--- a/technical-reports/format/terminology.md
+++ b/technical-reports/format/terminology.md
@@ -1,6 +1,6 @@
 # Terminology
 
-These definitions are focused on the technical aspects of the specification, aimed at implementers such as design tools vendors. Definitions for designers and developers are available at [designtokens.org](https://www.designtokens.org/glossary/).
+These definitions are focused on the technical aspects of the specification, aimed at implementers such as [=design tool=] vendors. Definitions for designers and developers are available at [designtokens.org](https://www.designtokens.org/glossary/).
 
 ## (Design) Token
 
@@ -24,7 +24,7 @@ For example:
 - Metadata
 - Description
 
-## Design tool
+## <dfn>Design tool</dfn>
 
 Visual design creation and editing tools.
 
@@ -70,7 +70,7 @@ Token tools can use Types to infer the purpose of a token.
 For example:
 
 - A [translation tool](#translation-tool) might reference a token's type to convert the source value into the correct platform-specific format.
-- A visual [design tool](#design-tool) might reference type to present tokens in the appropriate part of their UI - as in, color tokens are listed in the color picker, font tokens in the text styling UI's fonts list, and so on.
+- A visual [=design tool=] might reference type to present tokens in the appropriate part of their UI - as in, color tokens are listed in the color picker, font tokens in the text styling UI's fonts list, and so on.
 
 ## Groups
 

--- a/technical-reports/format/terminology.md
+++ b/technical-reports/format/terminology.md
@@ -44,7 +44,7 @@ This includes:
   - Figma
   - ...
 
-## Translation tool
+## <dfn>Translation tool</dfn>
 
 Token translation tools are tools that translate token data from one format to another.
 
@@ -69,7 +69,7 @@ Token tools can use Types to infer the purpose of a token.
 
 For example:
 
-- A [translation tool](#translation-tool) might reference a token's type to convert the source value into the correct platform-specific format.
+- A [=translation tool=] might reference a token's type to convert the source value into the correct platform-specific format.
 - A visual [=design tool=] might reference type to present tokens in the appropriate part of their UI - as in, color tokens are listed in the color picker, font tokens in the text styling UI's fonts list, and so on.
 
 ## Groups

--- a/technical-reports/format/types.md
+++ b/technical-reports/format/types.md
@@ -1,6 +1,6 @@
 # Types
 
-Many tools need to know what kind of value a given token represents to process it sensibly. Export tools MAY need to convert or format tokens differently depending on their type. Design tools MAY present the user with different kinds of input when editing tokens of a certain type (such as color picker, slider, text input, etc.). Style guide generators MAY use different kinds of previews for different types of tokens.
+Many tools need to know what kind of value a given token represents to process it sensibly. Export tools MAY need to convert or format tokens differently depending on their type. [=Design tools=] MAY present the user with different kinds of input when editing tokens of a certain type (such as color picker, slider, text input, etc.). Style guide generators MAY use different kinds of previews for different types of tokens.
 
 Since design token files are JSON files, all the basic JSON types are available:
 


### PR DESCRIPTION
This PR demonstrates how to link to definitions ([see documentation in ReSpec](https://respec.org/docs/#definitions-and-linking)).

If anyone finds this useful, please carry on adding more definition references!

It unlocks backlinks to the original definition for these terms. Here's how it looks like:

<img width="797" alt="Screen Shot 2022-04-26 at 2 24 20 PM" src="https://user-images.githubusercontent.com/85783/165590670-008e4f6b-6e7b-4fa6-a18a-410f4ee49bbb.png">

<img width="452" alt="Screen Shot 2022-04-26 at 2 24 08 PM" src="https://user-images.githubusercontent.com/85783/165590652-21110a83-929e-4db8-ac01-200af30b0f19.png">


