### PR TITLE
refactor(part 3): add documentation tool section, improve grammar & add some URLs

### DIFF
--- a/technical-reports/format/index.html
+++ b/technical-reports/format/index.html
@@ -114,7 +114,7 @@
           developers.
         </li>
         <li>
-          Documentation tools can display design token names rather than the raw
+          [=Documentation tools=] can display design token names rather than the raw
           values in design specs and style guides.
         </li>
       </ul>

--- a/technical-reports/format/index.html
+++ b/technical-reports/format/index.html
@@ -114,8 +114,8 @@
           developers.
         </li>
         <li>
-          [=Documentation tools=] can display design token names rather than the raw
-          values in design specs and style guides.
+          [=Documentation tools=] can display design token names rather than the
+          raw values in design specs and style guides.
         </li>
       </ul>
       <p>

--- a/technical-reports/format/terminology.md
+++ b/technical-reports/format/terminology.md
@@ -26,7 +26,7 @@ For example:
 
 ## <dfn>Design tool</dfn>
 
-A Design tool is a tool for visual design creation and editing.
+A design tool is a tool for visual design creation and editing.
 
 For example:
 
@@ -41,12 +41,12 @@ For example:
   - [Adobe XD](https://www.adobe.com/products/xd.html)
   - [UXPin](https://www.uxpin.com/)
   - [Sketch](https://www.sketch.com/)
-  - [Figma]https://www.figma.com/()
+  - [Figma](https://www.figma.com/)
   - ...
 
 ## <dfn>Translation tool</dfn>
 
-A token's translation tool is a tool that translates token data from one format to another.
+Design token translation tools translate token data from one format to another.
 
 For example:
 

--- a/technical-reports/format/terminology.md
+++ b/technical-reports/format/terminology.md
@@ -26,22 +26,22 @@ For example:
 
 ## <dfn>Design tool</dfn>
 
-Visual design creation and editing tools.
+Design tools are tools for visual design creation and editing.
 
-This includes:
+For example:
 
 - Bitmap image manipulation programs:
-  - Photoshop
-  - Affinity Photo
-  - Paint.net
+  - [Photoshop](https://www.adobe.com/products/photoshop.html)
+  - [Affinity Photo](https://affinity.serif.com/photo)
+  - [Paint.net](https://www.getpaint.net/)
 - Vector graphics tools:
-  - Illustrator
-  - Inkscape
-- UI design and prototyping tools:
-  - Adobe XD
-  - UXPin
-  - Sketch
-  - Figma
+  - [Illustrator](https://www.adobe.com/products/illustrator.html)
+  - [Inkscape](https://inkscape.org/)
+- UI design, wireframing and prototyping tools:
+  - [Adobe XD](https://www.adobe.com/products/xd.html)
+  - [UXPin](https://www.uxpin.com/)
+  - [Sketch](https://www.sketch.com/)
+  - [Figma]https://www.figma.com/()
   - ...
 
 ## <dfn>Translation tool</dfn>
@@ -54,6 +54,18 @@ For example:
 - [Style Dictionary](https://amzn.github.io/style-dictionary/)
 - [Diez](https://diez.org/)
 - [Specify](https://specifyapp.com/)
+- ...
+
+## <dfn>Documentation tool</dfn>
+
+Documentation tools are tools for documenting design tokens usage.
+
+For example:
+
+- [Storybook](https://github.com/salesforce-ux/theo)
+- [Zeroheight](https://amzn.github.io/style-dictionary/)
+- [Backlight](https://backlight.dev/)
+- ...
 
 ## Type
 

--- a/technical-reports/format/terminology.md
+++ b/technical-reports/format/terminology.md
@@ -4,7 +4,7 @@ These definitions are focused on the technical aspects of the specification, aim
 
 ## (Design) Token
 
-Information associated with a name, at minimum a name/value pair.
+A (Design) Token is an information associated with a name, at minimum a name/value pair.
 
 For example:
 
@@ -26,7 +26,7 @@ For example:
 
 ## <dfn>Design tool</dfn>
 
-Design tools are tools for visual design creation and editing.
+A Design tool is a tool for visual design creation and editing.
 
 For example:
 
@@ -46,7 +46,7 @@ For example:
 
 ## <dfn>Translation tool</dfn>
 
-Token translation tools are tools that translate token data from one format to another.
+A token's translation tool is a tool that translates token data from one format to another.
 
 For example:
 
@@ -58,7 +58,7 @@ For example:
 
 ## <dfn>Documentation tool</dfn>
 
-Documentation tools are tools for documenting design tokens usage.
+A documentation tool is a tool for documenting design tokens usage.
 
 For example:
 
@@ -84,9 +84,9 @@ For example:
 - A [=translation tool=] might reference a token's type to convert the source value into the correct platform-specific format.
 - A visual [=design tool=] might reference type to present tokens in the appropriate part of their UI - as in, color tokens are listed in the color picker, font tokens in the text styling UI's fonts list, and so on.
 
-## Groups
+## Group
 
-Sets of tokens belonging to a specific category.
+A group is a set of tokens belonging to a specific category.
 
 For example:
 

--- a/technical-reports/format/terminology.md
+++ b/technical-reports/format/terminology.md
@@ -65,6 +65,9 @@ For example:
 - [Storybook](https://storybook.js.org/)
 - [Zeroheight](https://zeroheight.com)
 - [Backlight](https://backlight.dev/)
+- [Specify](https://specifyapp.com/)
+- [Supernova](https://www.supernova.io/)
+- [Knapsack](https://www.knapsack.cloud/)
 - ...
 
 ## Type

--- a/technical-reports/format/terminology.md
+++ b/technical-reports/format/terminology.md
@@ -62,8 +62,8 @@ A documentation tool is a tool for documenting design tokens usage.
 
 For example:
 
-- [Storybook](https://github.com/salesforce-ux/theo)
-- [Zeroheight](https://amzn.github.io/style-dictionary/)
+- [Storybook](https://storybook.js.org/)
+- [Zeroheight](https://zeroheight.com)
 - [Backlight](https://backlight.dev/)
 - ...
 


### PR DESCRIPTION
Hello,

_First of all, a huge thank you to all the people who have contributed so far to this wonderful initiative.
Being passionate about UI and standardization, I loved reading the second draft and I want to be part of the contributors by proposing some changes that I hope you will like._

## Proposals

In this PR, I propose you several things:

- to add a documentation tool section because I noticed in the introduction, it was the only one between "design tool" and "translation tool" that didn't have an appropriate section:

![CleanShot 2022-07-01 at 01 49 32@2x](https://user-images.githubusercontent.com/9600228/176796621-7953178c-d3f4-4351-9eb8-5616532546d8.png)

- to be more consistent regarding grammar between design, translation & documentation tools
- to align titles & sentences to singular
- to add URLs for design tools

Please, don't hesitate if you have any remarks.

Thanks in advance for your review!