### PR TITLE
refactor(part 6.2.2): fix overflow-x caused by a non responsive image

### DIFF
--- a/technical-reports/format/groups.md
+++ b/technical-reports/format/groups.md
@@ -232,7 +232,10 @@ For example:
 
 Tools that let users pick or edit tokens via a GUI MAY use the grouping structure to display a suitable form of progressive disclosure, such as a collapsible tree view.
 
-<img src="./group-progressive-disclosure.png" alt="Progressive disclosure groups" style="width:100%; height: auto;" />
+<figure id="figure-group-progressive-disclosure">
+  <img src="./group-progressive-disclosure.png" alt="" />
+  <figcaption>Progressive disclosure groups</figcaption>
+</figure>
 
 ### Export tools
 

--- a/technical-reports/format/groups.md
+++ b/technical-reports/format/groups.md
@@ -232,7 +232,7 @@ For example:
 
 Tools that let users pick or edit tokens via a GUI MAY use the grouping structure to display a suitable form of progressive disclosure, such as a collapsible tree view.
 
-![Progressive disclosure groups](./group-progressive-disclosure.png)
+<img src="./group-progressive-disclosure.png" alt="Progressive disclosure groups" style="width:100%; height: auto;" />
 
 ### Export tools
 


### PR DESCRIPTION
Hello,

_First of all, a huge thank you to all the people who have contributed so far to this wonderful initiative.
Being passionate about UI and standardization, I loved reading the second draft and I want to be part of the contributors by proposing some changes that I hope you will like._

In this PR, I propose you to fix a UI bug in the format module documentation.

## Bug description

Because of the image in part 6.2.2 "GUI Tools" was declared in Markdown format, it generated an image with a fixed width of `426px`. Setting a `width: 100%` and `max-width: 426px` solves this problem for mobile screens.

## Before

<img width="569" alt="CleanShot 2022-07-01 at 02 06 19@2x" src="https://user-images.githubusercontent.com/9600228/176798231-2f454b63-196b-45cd-9ef5-77e85e85c489.png">

## After

<img width="530" alt="CleanShot 2022-07-01 at 02 05 58@2x" src="https://user-images.githubusercontent.com/9600228/176798224-d12689db-200a-4d92-a9c9-bc05588e695c.png">

Please, don't hesitate if you have any remarks.

Thanks in advance for your review!