### PR TITLE
refactor(vocabulary): rename "export tool" => "translation tool"

### DIFF
--- a/technical-reports/color/color-type.md
+++ b/technical-reports/color/color-type.md
@@ -1,6 +1,6 @@
 # The color type
 
-Represents a 24bit RGB or 24+8bit RGBA color in the sRGB color space. The `$type` property MUST be set to the string `color`. The value MUST be a string containing a hex triplet/quartet including the preceding `#` character. To support other color spaces, such as HSL, export tools SHOULD convert color tokens to the equivalent value as needed.
+Represents a 24bit RGB or 24+8bit RGBA color in the sRGB color space. The `$type` property MUST be set to the string `color`. The value MUST be a string containing a hex triplet/quartet including the preceding `#` character. To support other color spaces, such as HSL, translation tools SHOULD convert color tokens to the equivalent value as needed.
 
 For example, initially the color tokens MAY be defined as such:
 

--- a/technical-reports/format/design-token.md
+++ b/technical-reports/format/design-token.md
@@ -36,7 +36,7 @@ Token names are case-sensitive, so the following example with 2 tokens in the sa
 
 </aside>
 
-However, some tools MAY need to transform names when exporting to other languages or displaying names to the user, so having token names that differ only in case is likely to cause identical and undesirable duplicates in the output. For example, an export tool that converts these tokens to Sass code would generate problematic output like this:
+However, some tools MAY need to transform names when exporting to other languages or displaying names to the user, so having token names that differ only in case is likely to cause identical and undesirable duplicates in the output. For example, a translation tool that converts these tokens to Sass code would generate problematic output like this:
 
 <aside class="example">
 
@@ -79,7 +79,7 @@ For example:
 - Style guide generators MAY display the description text alongside a visual preview of the token
 - IDEs MAY display the description as a tooltip for auto-completion (similar to how API docs are displayed)
 - [=Design tools=] MAY display the description as a tooltip or alongside tokens wherever they can be selected
-- Export tools MAY render the description to a source code comment alongside the variable or constant they export.
+- Translation tools MAY render the description to a source code comment alongside the variable or constant they export.
 
 The value of the `$description` property MUST be a plain JSON string, for example:
 

--- a/technical-reports/format/groups.md
+++ b/technical-reports/format/groups.md
@@ -127,7 +127,7 @@ For example:
 Suggested ways tools MAY use this property are:
 
 - A style guide generator could render a section for each group and use the description as an introductory paragraph
-- A Design tool that lets users browse or select tokens could display this info alongside the corresponding group or as a tooltip
+- A GUI tool that lets users browse or select tokens could display this info alongside the corresponding group or as a tooltip
 - Translation tools could output this as a source code comment
 
 <div class="issue" data-number="72">
@@ -228,7 +228,7 @@ For example:
 
 </aside>
 
-### Design tools
+### GUI tools
 
 Tools that let users pick or edit tokens via a GUI MAY use the grouping structure to display a suitable form of progressive disclosure, such as a collapsible tree view.
 

--- a/technical-reports/format/groups.md
+++ b/technical-reports/format/groups.md
@@ -127,8 +127,8 @@ For example:
 Suggested ways tools MAY use this property are:
 
 - A style guide generator could render a section for each group and use the description as an introductory paragraph
-- A GUI tool that lets users browse or select tokens could display this info alongside the corresponding group or as a tooltip
-- Export tools could output this as a source code comment
+- A Design tool that lets users browse or select tokens could display this info alongside the corresponding group or as a tooltip
+- Translation tools could output this as a source code comment
 
 <div class="issue" data-number="72">
 
@@ -228,15 +228,15 @@ For example:
 
 </aside>
 
-### GUI tools
+### Design tools
 
 Tools that let users pick or edit tokens via a GUI MAY use the grouping structure to display a suitable form of progressive disclosure, such as a collapsible tree view.
 
 ![Progressive disclosure groups](./group-progressive-disclosure.png)
 
-### Export tools
+### Translation tools
 
-Token names are not guaranteed to be unique within the same file. The same name can be used in different groups. Also, export tools MAY need to export design tokens in a uniquely identifiable way, such as variables in code. Export tools SHOULD therefore use design tokens' paths as these _are_ unique within a file.
+Token names are not guaranteed to be unique within the same file. The same name can be used in different groups. Also, translation tools MAY need to export design tokens in a uniquely identifiable way, such as variables in code. Translation tools SHOULD therefore use design tokens' paths as these _are_ unique within a file.
 
 For example, a [=translation tool=] like [Style Dictionary](https://amzn.github.io/style-dictionary/) might use the following design token file:
 

--- a/technical-reports/format/types.md
+++ b/technical-reports/format/types.md
@@ -1,6 +1,6 @@
 # Types
 
-Many tools need to know what kind of value a given token represents to process it sensibly. Export tools MAY need to convert or format tokens differently depending on their type. [=Design tools=] MAY present the user with different kinds of input when editing tokens of a certain type (such as color picker, slider, text input, etc.). Style guide generators MAY use different kinds of previews for different types of tokens.
+Many tools need to know what kind of value a given token represents to process it sensibly. Translation tools MAY need to convert or format tokens differently depending on their type. [=Design tools=] MAY present the user with different kinds of input when editing tokens of a certain type (such as color picker, slider, text input, etc.). Style guide generators MAY use different kinds of previews for different types of tokens.
 
 Since design token files are JSON files, all the basic JSON types are available:
 
@@ -19,7 +19,7 @@ If an explicit type is set, but the value does not match the expected syntax the
 
 ## Color
 
-Represents a 24bit RGB or 24+8bit RGBA color in the sRGB color space. The `$type` property MUST be set to the string `color`. The value MUST be a string containing a hex triplet/quartet including the preceding `#` character. To support other color spaces, such as HSL, export tools SHOULD convert color tokens to the equivalent value as needed.
+Represents a 24bit RGB or 24+8bit RGBA color in the sRGB color space. The `$type` property MUST be set to the string `color`. The value MUST be a string containing a hex triplet/quartet including the preceding `#` character. To support other color spaces, such as HSL, translation tools SHOULD convert color tokens to the equivalent value as needed.
 
 For example, initially the color tokens MAY be defined as such:
 
@@ -77,8 +77,8 @@ For example:
 
 The "px" and "rem" units are to be interpreted the same way they are in CSS:
 
-- **px**: Represents an idealized pixel on the viewport. The equivalent in Android is dp and iOS is pt. Export tools SHOULD therefore convert to these or other equivalent units as needed.
-- **rem**: Represents a multiple of the system's default font size (which MAY be configurable by the user). 1rem is 100% of the default font size. The equivalent of 1rem on Android is 16sp. Not all platforms have an equivalent to rem, so export tools MAY need to do a lossy conversion to a fixed px size by assuming a default font size (usually 16px) for such platforms.
+- **px**: Represents an idealized pixel on the viewport. The equivalent in Android is dp and iOS is pt. Translation tools SHOULD therefore convert to these or other equivalent units as needed.
+- **rem**: Represents a multiple of the system's default font size (which MAY be configurable by the user). 1rem is 100% of the default font size. The equivalent of 1rem on Android is 16sp. Not all platforms have an equivalent to rem, so translation tools MAY need to do a lossy conversion to a fixed px size by assuming a default font size (usually 16px) for such platforms.
 
 ## Font family
 


### PR DESCRIPTION
In order to be more consistent, I've proposed to align terms of "export tool" & "translation tool".

So, this PR is there to close my issue about this: closes #152

Btw, thanks a lot @c1rrus for your comment on this:

> Good point!
> 
> I think you're right, we've used multiple terms to mean the same thing and ought to clean that up.

Feel free if you want to challenge :)

Have a nice day,