### PR TITLE
fix: groups link

### DIFF
--- a/technical-reports/format/design-token.md
+++ b/technical-reports/format/design-token.md
@@ -54,7 +54,7 @@ Tools MAY display a warning when token names differ only by case.
 
 ### Character restrictions
 
-All properties defined by this format are prefixed with the dollar sign (`$`). This convention will also be used for any new properties introduced by future versions of this spec. Therefore, token and [group](#groups-0) names MUST NOT begin with the `$` character.
+All properties defined by this format are prefixed with the dollar sign (`$`). This convention will also be used for any new properties introduced by future versions of this spec. Therefore, token and [group](#groups) names MUST NOT begin with the `$` character.
 
 Furthermore, due to the syntax used for [token aliases](#aliases-references) the following characters MUST NOT be used anywhere in a token or group name:
 


### PR DESCRIPTION
I was reading through the proposal (which I'm so excited about ✨ ) and noticed a broken link to the group section. I wanted to at least put this up to help and ensure screen readers and other page navigation tools can easily traverse the document.

I ran the `build` task and it modified a few other files I didn't check in so let me know if there is something I'm missing 🤷‍♂️ 