### PR TITLE
Adds new token property (`$private`)

### DIFF
--- a/technical-reports/format/design-token.md
+++ b/technical-reports/format/design-token.md
@@ -130,6 +130,36 @@ For example:
 
 </aside>
 
+## Private
+
+Marks a token as private.
+
+Private tokens can be used to create aliases and other token combinations, reducing duplication and simplifying token outputs. Tools can resolve private tokens internally, but should not look to make them publicly available by default.
+
+A token's visibility can be specified by the optional `$private` property. If the `$private` property is not set to `true` on a token, then the token's visibility is visible.
+
+The `$private` property can be set on different levels:
+
+- at the group level
+- at the token level
+
+The value of the `$private` property MUST be a boolean, whose value is either `true` or `false`.
+
+For example:
+
+<aside class="example">
+
+```json
+{
+  "Button background": {
+    "$value": "#777777",
+    "$private": true
+  }
+}
+```
+
+</aside>
+
 ## Extensions
 
 The optional **`$extensions`** property is an object where tools MAY add proprietary, user-, team- or vendor-specific data to a design token. When doing so, each tool MUST use a vendor-specific key whose value MAY be any valid JSON data.


### PR DESCRIPTION
Adds support for private tokens, to make defining tokens easier, without bloating any token outputs.

A simple use case could be using internal color palettes to create gradients, for example:

```json
{
  "color": {
    "$private": true,
    "red": {
      "$value": "red"
    },
    "orange": {
      "$value": "orange"
    },
    "yellow": {
      "$value": "yellow"
    },
    "green": {
      "$value": "green"
    },
    "blue": {
      "$value": "blue"
    },
    "indigo": {
      "$value": "indigo"
    },
    "violet": {
      "$value": "violet"
    }
  },
  "gradient": {
    "$type": "gradient",
    "rainbow": {
      "$value": [
        {
          "color": "{color.red}",
          "position": "0"
        },
        {
          "color": "{color.orange}",
          "position": "0.166"
        },
        {
          "color": "{color.yellow}",
          "position": "0.333"
        },
        {
          "color": "{color.green}",
          "position": "0.5"
        },
        {
          "color": "{color.blue}",
          "position": "0.666"
        },
        {
          "color": "{color.indigo}",
          "position": "0.833"
        },
        {
          "color": "{color.violet}",
          "position": "1"
        }
      ]
    }
  }
}
```