### PR TITLE
Update metadata mention in terminology section

### DIFF
--- a/technical-reports/format/terminology.md
+++ b/technical-reports/format/terminology.md
@@ -21,8 +21,9 @@ For example:
 
 - Value
 - Type
-- Metadata
 - Description
+
+Additional metadata may be added by tools and design systems to extend the format as needed.
 
 ## <dfn>Design tool</dfn>
 


### PR DESCRIPTION
The term "Metadata" in the list of "Information associated with a token name" has created confusion since there is no property in the spec called `$metadata`. 

This PR seeks to eliminate the confusion by alluding to the purpose of metadata in section 3.2 without explicitly mentioning the `$extensions` property which is covered later in section 5.5.

Closes #155 