### PR TITLE
Promote usage of a generic family name in the array example

### DIFF
--- a/technical-reports/format/types.md
+++ b/technical-reports/format/types.md
@@ -101,7 +101,7 @@ For example:
     "$type": "fontFamily"
   },
   "Body font": {
-    "$value": ["Helvetica", "Arial"],
+    "$value": ["Helvetica", "Arial", "sans-serif"],
     "$type": "fontFamily"
   }
 }


### PR DESCRIPTION
While the issue of typing the font-family is still open (https://github.com/design-tokens/community-group/issues/53), I think it could still be a good idea to list a generic font-family name in the array example as a generally good practice, for example, see [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/font-family):

> You should always include at least one generic family name in a font-family list, since there's no guarantee that any given font is available.