### PR TITLE
Fix the color alpha syntax to be 50%

### DIFF
--- a/technical-reports/color/color-type.md
+++ b/technical-reports/color/color-type.md
@@ -13,7 +13,7 @@ For example, initially the color tokens MAY be defined as such:
     "$type": "color"
   },
   "Translucent shadow": {
-    "$value": "#00000088",
+    "$value": "#00000080",
     "$type": "color"
   }
 }

--- a/technical-reports/format/composite-types.md
+++ b/technical-reports/format/composite-types.md
@@ -18,7 +18,7 @@ A design token whose type happens to be a composite type is sometimes also calle
   "shadow-token": {
     "$type": "shadow",
     "$value": {
-      "color": "#00000088",
+      "color": "#00000080",
       "offsetX": "0.5rem",
       "offsetY": "0.5rem",
       "blur": "1.5rem",
@@ -44,7 +44,7 @@ A design token whose type happens to be a composite type is sometimes also calle
   "color": {
     "shadow-050": {
       "$type": "color",
-      "$value": "#00000088"
+      "$value": "#00000080"
     }
   },
 
@@ -287,7 +287,7 @@ Represents a shadow style. The `$type` property MUST be set to the string `shado
   "shadow-token": {
     "$type": "shadow",
     "$value": {
-      "color": "#00000088",
+      "color": "#00000080",
       "offsetX": "0.5rem",
       "offsetY": "0.5rem",
       "blur": "1.5rem",

--- a/technical-reports/format/terminology.md
+++ b/technical-reports/format/terminology.md
@@ -123,7 +123,7 @@ Here's [an example of a composite shadow token](https://design-tokens.github.io/
   "shadow-token": {
     "$type": "shadow",
     "$value": {
-      "color": "#00000088",
+      "color": "#00000080",
       "offsetX": "0.5rem",
       "offsetY": "0.5rem",
       "blur": "1.5rem",

--- a/technical-reports/format/types.md
+++ b/technical-reports/format/types.md
@@ -32,7 +32,7 @@ For example, initially the color tokens MAY be defined as such:
     "$type": "color"
   },
   "Translucent shadow": {
-    "$value": "#00000088",
+    "$value": "#00000080",
     "$type": "color"
   }
 }


### PR DESCRIPTION
Noticed an issue with the [Example 15](https://design-tokens.github.io/community-group/format/#example-15) and [https://design-tokens.github.io/community-group/format/#example-16](Example16): Per the spec text, the 24 bit color value is expected to be transformed into a color with the alpha value of `50%`, while `88` would be actually around `53%`, being a common misconception when writing the component in 8bit format.

This PR changes any mentioned `#00000088` colors to `#00000080` to match the intent and fix the examples.