### PR TITLE
Clarify that 0 needs a unit as well.

### DIFF
--- a/technical-reports/format/types.md
+++ b/technical-reports/format/types.md
@@ -66,7 +66,11 @@ For example:
 
 ```json
 {
-  "spacingStack1X": {
+  "spacing-stack-0": {
+    "$value": "0rem",
+    "$type": "dimension"
+  },
+  "spacing-stack-1": {
     "$value": "0.25rem",
     "$type": "dimension"
   }

--- a/technical-reports/format/types.md
+++ b/technical-reports/format/types.md
@@ -58,7 +58,7 @@ $translucent-shadow: hsla(300, 100%, 50%, 0.5);
 
 ## Dimension
 
-Represents an amount of distance in a single dimension in the UI, such as a position, width, height, radius, or thickness. The `$type` property MUST be set to the string `dimension`. The value must be a string containing a number (either integer or floating-point) followed by either a "px" or "rem" unit (future spec iterations may add support for additional units).
+Represents an amount of distance in a single dimension in the UI, such as a position, width, height, radius, or thickness. The `$type` property MUST be set to the string `dimension`. The value must be a string containing a number (either integer or floating-point) followed by either a "px" or "rem" unit (future spec iterations may add support for additional units). This includes `0` which also MUST be followed by either a "px" or "rem" unit.
 
 For example:
 


### PR DESCRIPTION
This question has come up numerous times at my work.

In css `0` needs no unit as units are multiplied with the number and `0*px === 0`.

However the way I understand the specs this is not true atm for design tokens, correct?

In this case it would be great to clarify this. 