### PR TITLE
Removes JSON types and makes absence of (inherited) $type invalid

### DIFF
--- a/technical-reports/format/aliases.md
+++ b/technical-reports/format/aliases.md
@@ -17,7 +17,8 @@ For example:
 {
   "group name": {
     "token name": {
-      "$value": 1234
+      "$value": 1234,
+      "$type": "number"
     }
   },
   "alias name": {

--- a/technical-reports/format/composite-types.md
+++ b/technical-reports/format/composite-types.md
@@ -416,7 +416,7 @@ Represents a typographic style. The `$type` property MUST be set to the string `
 - `fontSize`: The size of the typography. The value of this property MUST be a valid [dimension value](#dimension) or a reference to a dimension token.
 - `fontWeight`: The weight of the typography. The value of this property MUST be a valid [font weight](#font-weight) or a reference to a font weight token.
 - `letterSpacing`: The horizontal spacing between characters. The value of this property MUST be a valid [dimension value](#dimension) or a reference to a dimension token.
-- `lineHeight`: The vertical spacing between lines of typography. The value of this property MUST be a valid [dimension value](#dimension) or [number value](#number) (in which case it should be interpreted as a unitless line height), or a reference to a dimension or number token.
+- `lineHeight`: The vertical spacing between lines of typography. The value of this property MUST be a valid [number value](#number) or a reference to a number token. The number SHOULD be interpreted as a multiplier of the `fontSize`.
 
 <aside class="example" title="Typography composite token examples">
 
@@ -440,7 +440,7 @@ Represents a typographic style. The `$type` property MUST be set to the string `
         "fontSize": "{font.size.smallest}",
         "fontWeight": "{font.weight.normal}",
         "letterSpacing": "0px",
-        "lineHeight": "24px"
+        "lineHeight": 1
       }
     }
   }

--- a/technical-reports/format/composite-types.md
+++ b/technical-reports/format/composite-types.md
@@ -374,6 +374,7 @@ Describes a gradient that is solid yellow for the first 2/3 and then fades to re
   },
 
   "position-end": {
+    "$type": "number",
     "$value": 1
   },
 
@@ -415,7 +416,7 @@ Represents a typographic style. The `$type` property MUST be set to the string `
 - `fontSize`: The size of the typography. The value of this property MUST be a valid [dimension value](#dimension) or a reference to a dimension token.
 - `fontWeight`: The weight of the typography. The value of this property MUST be a valid [font weight](#font-weight) or a reference to a font weight token.
 - `letterSpacing`: The horizontal spacing between characters. The value of this property MUST be a valid [dimension value](#dimension) or a reference to a dimension token.
-- `lineHeight`: The vertical spacing between lines of typography. The value of this property MUST be a valid JSON string or a reference to a string token.
+- `lineHeight`: The vertical spacing between lines of typography. The value of this property MUST be a valid [dimension value](#dimension) or [number value](#number) (in which case it should be interpreted as a unitless line height), or a reference to a dimension or number token.
 
 <aside class="example" title="Typography composite token examples">
 
@@ -429,7 +430,7 @@ Represents a typographic style. The `$type` property MUST be set to the string `
         "fontSize": "42px",
         "fontWeight": "700",
         "letterSpacing": "0.1px",
-        "lineHeight": "1.2"
+        "lineHeight": 1.2
       }
     },
     "microcopy": {
@@ -439,7 +440,7 @@ Represents a typographic style. The `$type` property MUST be set to the string `
         "fontSize": "{font.size.smallest}",
         "fontWeight": "{font.weight.normal}",
         "letterSpacing": "0px",
-        "lineHeight": "1"
+        "lineHeight": "24px"
       }
     }
   }

--- a/technical-reports/format/design-token.md
+++ b/technical-reports/format/design-token.md
@@ -13,7 +13,7 @@
 }
 ```
 
-Note: The `$type` property has been added to ensure this example is valid. Please refer to the [type chapter](#type-0) for more details.
+Note: The `$type` property has been added to ensure this example is valid. Please refer to the [design token type chapter](#type-0) for more details.
 
 </aside>
 
@@ -125,7 +125,7 @@ The `$type` property can be set on different levels:
 - at the group level
 - at the token level
 
-The `$type` property MUST be a plain JSON string, whose value is one of the values specified in respective [type chapters](#types). The value of `$type` is case-sensitive.
+The `$type` property MUST be a plain JSON string, whose value is one of the values specified in this specification's respective type definitios. The value of `$type` is case-sensitive.
 
 For example:
 

--- a/technical-reports/format/design-token.md
+++ b/technical-reports/format/design-token.md
@@ -7,10 +7,13 @@
 ```json
 {
   "token name": {
-    "$value": "token value"
+    "$value": "#fff000",
+    "$type": "color"
   }
 }
 ```
+
+Note: The `$type` property has been added to ensure this example is valid. Please refer to the [type chapter](#type-0) for more details.
 
 </aside>
 
@@ -19,7 +22,8 @@ An object with a **`$value`** property is a token. Thus, `$value` is a reserved 
 The example above therefore defines 1 design token with the following properties:
 
 - Name: "token name"
-- Value: "token value"
+- Value: "#fff000"
+- Type: "color"
 
 Name and value are both **required**.
 
@@ -29,8 +33,15 @@ Token names are case-sensitive, so the following example with 2 tokens in the sa
 
 ```json
 {
-  "font-size": { "$value": "3rem" },
-  "FONT-SIZE": { "$value": "16px" }
+  "font-size": {
+    "$value": "3rem",
+    "$type": "dimension"
+  },
+
+  "FONT-SIZE": {
+    "$value": "16px",
+    "$type": "dimension"
+  }
 }
 ```
 
@@ -89,6 +100,7 @@ The value of the `$description` property MUST be a plain JSON string, for exampl
 {
   "Button background": {
     "$value": "#777777",
+    "$type": "color",
     "$description": "The background color for buttons in their normal state."
   }
 }
@@ -102,9 +114,9 @@ Design tokens always have an unambiguous type, so that tools can reliably interp
 
 A token's type can be specified by the optional `$type` property. If the `$type` property is not set on a token, then the token's type MUST be determined as follows:
 
-- If the token's value is a reference, then its type is the type of the token being referenced.
+- If the token's value is a reference, then its type is the resolved type of the token being referenced.
 - Otherwise, if any of the token's parent groups have a `$type` property, then the token's type is inherited from the closest parent group with a `$type` property.
-- Otherwise, the token's type is whichever of the basic JSON types (`string`, `number`, `boolean`, `object`, `array` or `null`) its value is.
+- Otherwise, if none of the parent groups have a `$type` property, the token's type cannot be determined and the token MUST be considered invalid.
 
 Tools MUST NOT attempt to guess the type of a token by inspecting the contents of its value.
 
@@ -113,7 +125,7 @@ The `$type` property can be set on different levels:
 - at the group level
 - at the token level
 
-The `$type` property MUST be a plain JSON string, whose value is `string`, `number`, `boolean`, `object`, `array`, `null` or one of the values specified in respective [type chapters](#types). The value of `$type` is case-sensitive.
+The `$type` property MUST be a plain JSON string, whose value is one of the values specified in respective [type chapters](#types). The value of `$type` is case-sensitive.
 
 For example:
 
@@ -143,6 +155,7 @@ The optional **`$extensions`** property is an object where tools MAY add proprie
 {
   "Button background": {
     "$value": "#777777",
+    "$type": "color",
     "$extensions": {
       "org.example.tool-a": 42,
       "org.example.tool-b": {

--- a/technical-reports/format/design-token.md
+++ b/technical-reports/format/design-token.md
@@ -125,7 +125,7 @@ The `$type` property can be set on different levels:
 - at the group level
 - at the token level
 
-The `$type` property MUST be a plain JSON string, whose value is one of the values specified in this specification's respective type definitios. The value of `$type` is case-sensitive.
+The `$type` property MUST be a plain JSON string, whose value is one of the values specified in this specification's respective type definitions. The value of `$type` is case-sensitive.
 
 For example:
 

--- a/technical-reports/format/groups.md
+++ b/technical-reports/format/groups.md
@@ -7,18 +7,22 @@ A file MAY contain many tokens and they MAY be nested arbitrarily in groups like
 ```json
 {
   "token uno": {
-    "$value": "token value 1"
+    "$value": "#111111",
+    "$type": "color"
   },
   "token group": {
     "token dos": {
-      "$value": "token value 2"
+      "$value": "2rem",
+      "$type": "dimension"
     },
     "nested token group": {
       "token tres": {
-        "$value": "token value 3"
+        "$value": 33,
+        "$type": "number"
       },
       "Token cuatro": {
-        "$value": "token value 4"
+        "$value": 444,
+        "$type": "fontWeight"
       }
     }
   }
@@ -32,19 +36,23 @@ The names of the groups leading to a given token (including that token's name) a
 - Token #1
   - Name: "token uno"
   - Path: "token uno"
-  - Value: "token value 1"
+  - Value: "#111111"
+  - Type: "color"
 - Token #2
   - Name: "token dos"
   - Path: "token group" / "token dos"
-  - Value: "token value 2"
+  - Value: "2rem"
+  - Type: "dimension"
 - Token #3
   - Name: "token tres"
   - Path: "token group" / "nested token group" / "token tres"
-  - Value: "token value 3"
+  - Value: 33
+  - Type: "number"
 - Token #4
   - Name: "token cuatro"
   - Path: "token group" / "nested token group" / "token cuatro"
-  - Value: "token value 4"
+  - Value: 444
+  - Type: "fontWeight"
 
 Because groupings are arbitrary, tools MUST NOT use them to infer the type or purpose of design tokens.
 

--- a/technical-reports/format/types.md
+++ b/technical-reports/format/types.md
@@ -2,18 +2,11 @@
 
 Many tools need to know what kind of value a given token represents to process it sensibly. Translation tools MAY need to convert or format tokens differently depending on their type. [=Design tools=] MAY present the user with different kinds of input when editing tokens of a certain type (such as color picker, slider, text input, etc.). Style guide generators MAY use different kinds of previews for different types of tokens.
 
-Since design token files are JSON files, all the basic JSON types are available:
+This spec defines a number of design-focused types and every design token MUST use one of these types. Furthermore, that token's value MUST then follow rules and syntax for the chosen type as defined by this spec.
 
-- String
-- Number
-- Object
-- Array
-- Boolean
-- Null
+A token's type can be set directly by giving it a `$type` property specifying the chosen type. Alternatively, it can inherit a type from one of its parent groups, or be an alias of a token that has the desired type.
 
-Additionally, this spec defines a number of more design-focused types. To set a token to one of these types, it MUST either have a `$type` property specifying the chosen type, inherit a type from one of its parent groups, or be an alias of a token that has the desired type. Furthermore, that token's value MUST then follow rules and syntax for the chosen type as defined by this spec.
-
-If no explicit type has been set for a token, tools MUST treat values as one of the basic JSON types and not attempt to infer any other type from the value.
+If no explicit type has been set for a token, tools MUST consider the token invalid and not attempt to infer any other type from the value.
 
 If an explicit type is set, but the value does not match the expected syntax then that token is invalid and an appropriate error SHOULD be displayed to the user. To put it another way, the `$type` property is a declaration of what kind of values are permissible for the token. (This is similar to typing in programming languages like Java or TypeScript, where a value not compatible with the declared type causes a compilation error).
 
@@ -189,6 +182,23 @@ For example:
   "Decelerate": {
     "$value": [0, 0, 0.5, 1],
     "$type": "cubicBezier"
+  }
+}
+```
+
+</aside>
+
+## Number
+
+Represents a number. Numbers can be positive, negative and have fractions. Example uses for number tokens are [gradient stop positions](#gradient) or unitless line heights. The `$type` property MUST be set to the string `number`. The value MUST be a JSON number value.
+
+<aside class="example">
+
+```json
+{
+  "line-height-large": {
+    "$value": 2.3,
+    "$type": "number"
   }
 }
 ```


### PR DESCRIPTION
Closes #120, #139

* Removes support for the JSON types (`string`, `boolean`, `null`, etc.)
    * Except for `number` which is now documented as one of the spec's types. This is because it was required by the `gradient` type.
* Changes the type resolution rules so that when there is no (inherited) `$type` present, a token must be considered invalid. Previously, it would fall back on to one of the JSON types.
* Fixes a bug (?) in the `typography` type, where `lineHeight` expected a `string` value.
    * I had to change this since `string` no longer exists. But also, it was never a useful type of value for that purpose. I've changed it to expect `number` values for now. We can always revise it if needed once we review and action the feedback provided in #102 
* Updates examples throughout the spec to ensure that they are valid now that the JSON types and associated type resolution fallback behaviour have been removed.

