### PR TITLE
Adds extensions to groups

### DIFF
--- a/technical-reports/format/groups.md
+++ b/technical-reports/format/groups.md
@@ -167,7 +167,7 @@ Group extensions follow the same rules as [design token extensions](#extensions)
 - The keys SHOULD be chosen such that they avoid the likelihood of a naming clash with another vendor's data. The [reverse domain name notation](https://en.wikipedia.org/wiki/Reverse_domain_name_notation) is recommended for this purpose.
 - Tools that process design token files MUST preserve any extension data they do not themselves understand. For example, if a group contains extension data from tool A and the file containing that data is opened by tool B, then tool B MUST include the original tool A extension data whenever it saves a new design token file containing that group.
 
-Note that, since a group's `$extensions` only relate to that group, they do not have any effect on nested groups or tokens. However, if an extension author wants their extension to be inherited by nested groups or tokens like a group's `$type` is, then they MAY implement that behaviour in whatever tools support their extension.
+Note that, since a group's `$extensions` only relate to that group, they do not have any effect on nested groups or tokens.
 
 <aside class="example">
 

--- a/technical-reports/format/groups.md
+++ b/technical-reports/format/groups.md
@@ -130,12 +130,6 @@ Suggested ways tools MAY use this property are:
 - A GUI tool that lets users browse or select tokens could display this info alongside the corresponding group or as a tooltip
 - Translation tools could output this as a source code comment
 
-<div class="issue" data-number="72">
-
-Groups may support additional properties like type and description. Should other properties be supported at the group level?
-
-</div>
-
 ### Type
 
 Groups MAY include an optional `$type` property so a type property does not need to be manually added to every token. [See supported "Types"](#types) for more information.
@@ -161,6 +155,46 @@ For example:
   }
 }
 ```
+
+</aside>
+
+### Extensions
+
+Groups MAY include an optional `$extensions` property where tools MAY add proprietary, user-, team- or vendor-specific data to a group. When doing so, each tool MUST use a vendor-specific key whose value MAY be any valid JSON data.
+
+Group extensions follow the same rules as [design token extensions](#extensions), the only difference is that they relate to the group itself.
+
+- The keys SHOULD be chosen such that they avoid the likelihood of a naming clash with another vendor's data. The [reverse domain name notation](https://en.wikipedia.org/wiki/Reverse_domain_name_notation) is recommended for this purpose.
+- Tools that process design token files MUST preserve any extension data they do not themselves understand. For example, if a group contains extension data from tool A and the file containing that data is opened by tool B, then tool B MUST include the original tool A extension data whenever it saves a new design token file containing that group.
+
+Note that, since a group's `$extensions` only relate to that group, they do not have any effect on nested groups or tokens. However, if an extension author wants their extension to be inherited by nested groups or tokens like a group's `$type` is, then they MAY implement that behaviour in whatever tools support their extension.
+
+<aside class="example">
+
+```json
+{
+  "brand": {
+    "$extensions": {
+      "org.example.tool-a": 42,
+      "org.example.tool-b": {
+        "turn-up-to-11": true
+      }
+    },
+    "color": {
+      "acid green": {
+        "$value": "#00ff66",
+        "$type": "color"
+      },
+      "hot pink": {
+        "$value": "#dd22cc",
+        "$type": "color"
+      }
+    }
+  }
+}
+```
+
+In this example, the "brand" group has 2 extensions: `org.example.tool-a` and `org.example.tool-b`.
 
 </aside>
 


### PR DESCRIPTION
Closes #106 

There seems to be a consensus that allowing groups to have `$extensions` (just like design tokens can), so this updates the spec accordingly.