### PR TITLE
Add Open edX to DTCG members in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ As vendors adopt the specification and new requirements appear, the community gr
 - [Marvel](https://marvelapp.com)
 - [Microsoft](https://www.microsoft.com/)
 - [Modulz](https://www.modulz.app)
+- [Open edX](https://openedx.org/)
 - [Philips Design](https://www.philips.com/a-w/about/philips-design.html)
 - [Salesforce](https://www.salesforce.com)
 - [Sass](https://www.sass-lang.com)


### PR DESCRIPTION
Hey there 👋 I'd love to list [Open edX](https://openedx.org/) as a DTCG member; just joined the W3C group. We've been working on migrating our open-source design system [Paragon](https://paragon-openedx.netlify.app/) ([Github](https://github.com/openedx/paragon)) to use design tokens with `style-dictionary` (which I also see represented!), and have been referring to the spec proposed by the DTCG. We also see the benefits of such a standard for design tokens and would love to get involved :) Thanks!