### PR TITLE
Update fontWeight to be number in Example 36

### DIFF
--- a/technical-reports/format/composite-types.md
+++ b/technical-reports/format/composite-types.md
@@ -428,7 +428,7 @@ Represents a typographic style. The `$type` property MUST be set to the string `
       "$value": {
         "fontFamily": "Roboto",
         "fontSize": "42px",
-        "fontWeight": "700",
+        "fontWeight": 700,
         "letterSpacing": "0.1px",
         "lineHeight": 1.2
       }


### PR DESCRIPTION
According to [font weight](https://design-tokens.github.io/community-group/format/#font-weight) section, it should be number instead of string `"700"`