### PR TITLE
Fix design token heading levels

### DIFF
--- a/technical-reports/format/design-token.md
+++ b/technical-reports/format/design-token.md
@@ -84,7 +84,7 @@ Furthermore, due to the syntax used for [token aliases](#aliases-references) the
 
 While `$value` is the only required property for a token, a number of additional properties MAY be added:
 
-## Description
+### Description
 
 A plain text description explaining the token's purpose can be provided via the optional `$description` property. Tools MAY use the description in various ways.
 
@@ -111,7 +111,7 @@ The value of the `$description` property MUST be a plain JSON string, for exampl
 
 </aside>
 
-## Type
+### Type
 
 Design tokens always have an unambiguous type, so that tools can reliably interpret their value.
 
@@ -145,7 +145,7 @@ For example:
 
 </aside>
 
-## Extensions
+### Extensions
 
 The optional **`$extensions`** property is an object where tools MAY add proprietary, user-, team- or vendor-specific data to a design token. When doing so, each tool MUST use a vendor-specific key whose value MAY be any valid JSON data.
 
@@ -178,5 +178,3 @@ Tool vendors are encouraged to publicly share specifications of their extension 
 <p class="ednote" title="Extensions section">
   The extensions section is not limited to vendors. All token users can add additional data in this section for their own purposes.
 </p>
-
-## More token properties TBC


### PR DESCRIPTION
## Changes

Fixes an unintentional heading level issue under “Design token”

**Before**

Section 5.2 seems to suggest that the following headings are underneath it (which would mirror Groups):

![before](https://github.com/user-attachments/assets/3806d007-353b-4ea9-95cd-3950f3b0f2fa)

**After**

Section 5.2 makes more sense with sub-headings (and makes Tokens and Groups consistent)

![after](https://github.com/user-attachments/assets/f996b8fb-d395-43bb-a5ac-5286f05f835d)
