### PR TITLE
Proposal: add $deprecated property

### DIFF
--- a/technical-reports/format/design-token.md
+++ b/technical-reports/format/design-token.md
@@ -181,7 +181,7 @@ Tool vendors are encouraged to publicly share specifications of their extension 
 
 ### Deprecated
 
-The optional **`$deprecated`** property is a boolean or string where tools MAY specify deprecated tokens. A token MAY be marked deprecated in any of the following scenarios:
+The **`$deprecated`** property MAY be used to mark a token as deprecated, and optionally explain the reason. Reasons to deprecate tokens include but are not limited to the following:
 
 - A future update to the design system will remove this token
 - Removing the token now may break existing support
@@ -199,7 +199,7 @@ The optional **`$deprecated`** property is a boolean or string where tools MAY s
   "Button focus": {
     "$value": "#70c0ff",
     "$type": "color",
-    "$deprecated": "Please use {button.activeBorder} instead."
+    "$deprecated": "Please use the border style for active buttons instead."
   }
 }
 ```
@@ -211,3 +211,27 @@ The optional **`$deprecated`** property is a boolean or string where tools MAY s
 | `true`   | This token is deprecated (no explanation provided).         |
 | `String` | This token is deprecated AND this is an explanation.        |
 | `false`  | This token is NOT deprecated (may override group defaults). |
+
+Tool makers MAY augment the string when it contains aliases such as the one given as an example. A tool could potentially resolve the token, and link to docs, code, or render a visual representation of it and link to the new token inside a UI. For example, “Please use {button.activeBorder} instead“ could be output in JS as:
+
+<aside class="example">
+
+```js
+/**
+ * @deprecated Please use {@link file://./my-tokens.js:85 button.activeBorder} instead.
+ */
+```
+
+</aside>
+
+Or
+
+<aside class="example">
+
+```js
+/**
+ * @deprecated Please use {@link https://docs.ds/tokens/#button-activeborder button.activeBorder} instead.
+ */
+```
+
+</aside>

--- a/technical-reports/format/design-token.md
+++ b/technical-reports/format/design-token.md
@@ -178,3 +178,36 @@ Tool vendors are encouraged to publicly share specifications of their extension 
 <p class="ednote" title="Extensions section">
   The extensions section is not limited to vendors. All token users can add additional data in this section for their own purposes.
 </p>
+
+### Deprecated
+
+The optional **`$deprecated`** property is a boolean or string where tooks MAY specify deprecated tokens. A token MAY be marked deprecated in any of the following scenarios:
+
+- A future update to the design system will remove this token
+- Removing the token now may break existing support
+- This token is discouraged from future use
+
+<aside class="example">
+
+```json
+{
+  "Button background": {
+    "$value": "#777777",
+    "$type": "color",
+    "$deprecated": true
+  },
+  "Button focus": {
+    "$value": "#70c0ff",
+    "$type": "color",
+    "$deprecated": "Please use {button.activeBorder} instead."
+  }
+}
+```
+
+</aside>
+
+| Value    | Explanation                                                 |
+| :------- | :---------------------------------------------------------- |
+| `true`   | This token is deprecated (no explanation provided).         |
+| `String` | This token is deprecated AND this is an explanation.        |
+| `false`  | This token is NOT deprecated (may override group defaults). |

--- a/technical-reports/format/design-token.md
+++ b/technical-reports/format/design-token.md
@@ -181,7 +181,7 @@ Tool vendors are encouraged to publicly share specifications of their extension 
 
 ### Deprecated
 
-The optional **`$deprecated`** property is a boolean or string where tooks MAY specify deprecated tokens. A token MAY be marked deprecated in any of the following scenarios:
+The optional **`$deprecated`** property is a boolean or string where tools MAY specify deprecated tokens. A token MAY be marked deprecated in any of the following scenarios:
 
 - A future update to the design system will remove this token
 - Removing the token now may break existing support

--- a/technical-reports/format/groups.md
+++ b/technical-reports/format/groups.md
@@ -208,18 +208,14 @@ In this example, the "brand" group has 2 extensions: `org.example.tool-a` and `o
 
 ### Deprecated
 
-The optional **`$deprecated`** property is a boolean or string where tools MAY specify all tokens within the group are deprecated. A token MAY be marked deprecated in any of the following scenarios:
-
-- A future update to the design system will remove this token
-- Removing the token now may break existing support
-- This token is discouraged from future use
+The **`$deprecated`** property MAY be used to mark a group as deprecated, which extends to all child tokens within. This property may also optionally give a reason.
 
 <aside class="example">
 
 ```json
 {
   "Button": {
-    "$deprecated": "Please use {action.*} tokens instead.",
+    "$deprecated": "Please use tokens in the Action group instead.",
     "Foreground": { "$value": "#202020", "$type": "color" },
     "Background": { "$value": "#ffffff", "$type": "color" }
   }

--- a/technical-reports/format/groups.md
+++ b/technical-reports/format/groups.md
@@ -208,7 +208,7 @@ In this example, the "brand" group has 2 extensions: `org.example.tool-a` and `o
 
 ### Deprecated
 
-The optional **`$deprecated`** property is a boolean or string where tooks MAY specify all tokens within the group are deprecated. A token MAY be marked deprecated in any of the following scenarios:
+The optional **`$deprecated`** property is a boolean or string where tools MAY specify all tokens within the group are deprecated. A token MAY be marked deprecated in any of the following scenarios:
 
 - A future update to the design system will remove this token
 - Removing the token now may break existing support

--- a/technical-reports/format/groups.md
+++ b/technical-reports/format/groups.md
@@ -206,6 +206,36 @@ In this example, the "brand" group has 2 extensions: `org.example.tool-a` and `o
 
 </aside>
 
+### Deprecated
+
+The optional **`$deprecated`** property is a boolean or string where tooks MAY specify all tokens within the group are deprecated. A token MAY be marked deprecated in any of the following scenarios:
+
+- A future update to the design system will remove this token
+- Removing the token now may break existing support
+- This token is discouraged from future use
+
+<aside class="example">
+
+```json
+{
+  "Button": {
+    "$deprecated": "Please use {action.*} tokens instead.",
+    "Foreground": { "$value": "#202020", "$type": "color" },
+    "Background": { "$value": "#ffffff", "$type": "color" }
+  }
+}
+```
+
+</aside>
+
+In the context of a group, adding `$deprecated` will apply to all tokens within that group, unless a token explicitly sets a value of `false`. Any value provided by a token will override the group default.
+
+| Value    | Explanation                                                 |
+| :------- | :---------------------------------------------------------- |
+| `true`   | This token is deprecated (no explanation provided).         |
+| `String` | This token is deprecated AND this is an explanation.        |
+| `false`  | This token is NOT deprecated (may override group defaults). |
+
 ## Use-cases
 
 ### File authoring & organization


### PR DESCRIPTION
## Summary

This adds a new `$deprecated` property for both tokens and groups [as suggested by @romainmenke](https://github.com/design-tokens/community-group/issues/118).

## Reasoning

This PR basically accepts #118 as-proposed (the original proposal), while taking into account feedback from followup comments.

### Pros

- This mirrors prior art like [JSDoc deprecation](https://jsdoc.app/tags-deprecated) that is well-known and well-used
- Style dictionary also [has this concept](https://github.com/design-tokens/community-group/issues/118#issuecomment-2277926212) and it makes sense to codify in the spec
- This seemed to have fairly-universal support (only disagreements were minor syntax differences, but that also spawned [a separate proposal](https://github.com/design-tokens/community-group/issues/161) that can be evaluated independently)

### Cons

- Expanding `$deprecated` in the future would be a breaking change
- What constitutes “deprecation” is a little ambiguous in the spec as-written. But the hope is that it’s no more ambiguous than using [this exact term elsewhere](https://jsdoc.app/tags-deprecated).
- What “deprecation” means is up to tools to decide (e.g. whether or not to generate output from those tokens, and/or throw warnings/errors)

## Alternatives

- Adding a pair property (e.g. `$deprecated` / `$deprecatedMessage`) isn’t a design pattern that currently exists in the spec. Pair properties can also be antipatterns as they introduce validation complexity (e.g. what if `$deprecatedMessage` is set but `$deprecated` isn’t—is that valid or invalid? and if valid, what behavior is inferred?)
- The object syntax (e.g. `$deprecated.deprecated` / `$deprecated.message`) wasn’t proposed here because it adds unnecessary boilerplate.
- A more complex [status object](https://github.com/design-tokens/community-group/issues/161) would be a separate proposal because that encroaches on opinionated versioning (and versioning won’t map 1:1 to existing tokens)
  - This proposal assumes that any implementation of status/versioning won’t conflict with `$deprecated`. Or in areas where they potentially overlap, will be complementary rather than conflicting.
  - In other words, acceptance of this does NOT mean refusal of the Status Object proposal

## Notes
- This assumes **aliases may be deprecated too** (even if the tokens they point to don’t). Should this be outlined explicitly?
- It is the author’s opinion that deprecation is not directly related to versioning. Versioning is a more complex opinion on what constitutes “breaking changes” from non-, e.g. [semver](https://semver.org/). Though versioning _may_ include deprecation and/or removal of tokens, it’s so much more. Conversely, the act of deprecation is common enough it affects every design system, even those that may not have defined versioning strategies. So whether or not this spec defines an opinionated versioning strategy, shouldn’t affect this proposal.