### PR TITLE
Shadow token examples dimension format

### DIFF
--- a/technical-reports/format/composite-types.md
+++ b/technical-reports/format/composite-types.md
@@ -310,32 +310,32 @@ Represents a shadow style. The `$type` property MUST be set to the string `shado
       "spread": { "value": 0, "unit": "rem" }
     }
   },
-  "layered-shadow": {
-    "$type": "shadow",
-    "$value": [
-      {
-        "color": "#00000005",
-        "offsetX": "0px",
-        "offsetY": "24px",
-        "blur": "22px",
-        "spread": "0px"
-      },
-      {
-        "color": "#0000000a",
-        "offsetX": "0px",
-        "offsetY": "42.9px",
-        "blur": "44px",
-        "spread": "0px"
-      },
-      {
-        "color": "#0000000f",
-        "offsetX": "0px",
-        "offsetY": "64px",
-        "blur": "64px",
-        "spread": "0px"
-      }
-    ]
-  },
+"layered-shadow": {
+  "$type": "shadow",
+  "$value": [
+    {
+      "color": "#00000005",
+      "offsetX": { "value": 0, "unit": "px" },
+      "offsetY": { "value": 24, "unit": "px" },
+      "blur": { "value": 22, "unit": "px" },
+      "spread": { "value": 0, "unit": "px" }
+    },
+    {
+      "color": "#0000000a",
+      "offsetX": { "value": 0, "unit": "px" },
+      "offsetY": { "value": 42.9, "unit": "px" },
+      "blur": { "value": 44, "unit": "px" },
+      "spread": { "value": 0, "unit": "px" }
+    },
+    {
+      "color": "#0000000f",
+      "offsetX": { "value": 0, "unit": "px" },
+      "offsetY": { "value": 64, "unit": "px" },
+      "blur": { "value": 64, "unit": "px" },
+      "spread": { "value": 0, "unit": "px" }
+    }
+  ]
+}
   "inner-shadow": {
     "$type": "shadow",
     "$value": {

--- a/technical-reports/format/composite-types.md
+++ b/technical-reports/format/composite-types.md
@@ -336,17 +336,17 @@ Represents a shadow style. The `$type` property MUST be set to the string `shado
     }
   ]
 }
-  "inner-shadow": {
-    "$type": "shadow",
-    "$value": {
-      "color": "#00000010",
-      "offsetX": "2px",
-      "offsetY": "2px",
-      "blur": "4px",
-      "spread": "0px",
-      "inset": true
-    }
+"inner-shadow": {
+  "$type": "shadow",
+  "$value": {
+    "color": "#00000010",
+    "offsetX": { "value": 2, "unit": "px" },
+    "offsetY": { "value": 2, "unit": "px" },
+    "blur": { "value": 4, "unit": "px" },
+    "spread": { "value": 0, "unit": "px" },
+    "inset": true
   }
+}
 }
 ```
 


### PR DESCRIPTION
# Fix Shadow Token Examples to Match Specification

Updated both the `layered-shadow` and `inner-shadow` examples to use the correct dimension object format:
- e.g. `"24px"` → `{ "value": 24, "unit": "px" }`

This ensures the examples are consistent with the dimension value specification as outlined in section 8.2.