### PR TITLE
Add Synology to the list of companies represented on the DTCG

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ As vendors adopt the specification and new requirements appear, the community gr
 - [Style Dictionary](https://amzn.github.io/style-dictionary)
 - [Superposition](https://superposition.design)
 - [Supernova](https://supernova.io)
+- [Synology](https://www.synology.com)
 - [system-ui](https://github.com/system-ui)
 - [Toolabs](https://www.toolabs.com)
 - [Tokens Studio](https://www.tokens.studio)


### PR DESCRIPTION
Hello 👋 As a frontend architecture leader, I’d like to list Synology as a DTCG member, as we're becoming increasingly involved with the group and actively integrating the format into our frontend architecture.