### PR TITLE
chore: add a versions overview to README, prevED prop for living draft

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,18 @@ As vendors adopt the specification and new requirements appear, the community gr
 - [zeroheight](https://www.zeroheight.com)
 - ex-contributors to [Theo](https://github.com/salesforce-ux/theo) (by Salesforce)
 
+## Versions
+
+Here's an overview of all of the published versions of this draft specification:
+
+| name            | url                                      | date       |
+| --------------- | ---------------------------------------- | ---------- |
+| editors-draft/1 | first-editors-draft.tr.designtokens.org  | 2021-09-23 |
+| editors-draft/2 | second-editors-draft.tr.designtokens.org | 2022-06-14 |
+| living-draft    | tr.designtokens.org                      | 2025-04-18 |
+
+> Note: tools can use the date as a version number to signify compliance. For example: `20250418`.
+
 ## Contributing
 
 See [CONTRIBUTING.md](https://github.com/design-tokens/community-group/blob/main/CONTRIBUTING.md).

--- a/technical-reports/index.html
+++ b/technical-reports/index.html
@@ -12,6 +12,7 @@
       const respecConfig = {
         specStatus: 'base',
         latestVersion: 'https://tr.designtokens.org/',
+        prevED: 'https://second-editors-draft.tr.designtokens.org/',
         edDraftURI: null,
         editors: [
           { name: 'Adekunle Oduye' },


### PR DESCRIPTION
See slack for versioning discussion. 

Even if we don't have semver (because it's not really the way of doing things for W3C community group specs it seems), it would help if the living draft that's published on tr.designtokens.org had a backlink to the previous editor draft. 

Furthermore, adding a versions overview at least to the README of this repo is useful for tools to see which versions there are, so they can more easily communicate to their users which version of the spec the tool is compliant with.