### PR TITLE
chore: add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,39 @@
+name: Bug
+description: Suggest an issue or typo either in the specification, or on the website
+body:
+  - type: dropdown
+    id: area
+    attributes:
+      label: Problem area
+      description: What is this an issue with?
+      multiple: true
+      options:
+        - Specification
+        - designtokens.org
+        - GitHub repo
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: summary
+    attributes:
+      label: Problem
+      description: Describe the issue in detail.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Suggested fix
+      description: What’s the suggested fix here?
+    validations:
+      required: true
+  - type: checkboxes
+    id: required_checks
+    attributes:
+      label: Required
+      options:
+        - label: I have searched [existing issues](https://github.com/design-tokens/community-group/issues) and there is not already an open issue on the subject.
+          required: true
+        - label: I have read and agree to abide by the [CODE_OF_CONDUCT](https://github.com/design-tokens/community-group/blob/CODE_OF_CONDUCT.md)
+          required: true

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -26,8 +26,6 @@ body:
     attributes:
       label: Suggested fix
       description: What’s the suggested fix here?
-    validations:
-      required: true
   - type: checkboxes
     id: required_checks
     attributes:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/proposal.yml
+++ b/.github/ISSUE_TEMPLATE/proposal.yml
@@ -1,6 +1,13 @@
 name: Proposal
 description: Suggest an addition or modification to the existing spec
 body:
+  - type: checkboxes
+    id: before_starting
+    attributes:
+      label: Before starting
+      options:
+        - label: I have searched [existing issues](https://github.com/design-tokens/community-group/issues) and there is not already an open issue on the subject.
+          required: true
   - type: textarea
     id: summary
     attributes:
@@ -21,23 +28,15 @@ body:
     validations:
       required: true
   - type: textarea
-    id: problem
+    id: detail
     attributes:
       label: Problem & motivation
-      description: In detail, what are the problem(s) you’re attempting to solve, either in your own design system or with the current specification syntax? List specific examples of how the current syntax doesn’t meet your needs.
-  - type: textarea
-    id: syntax
-    attributes:
-      label: Syntax
-      description: Describe the proposed syntax, in JSON format
-      render: json
-    validations:
-      required: true
+      description: In detail, what problem(s) are you attempting to solve? List out all relevant JSON syntax. [GitHub markdown](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) is supported.
   - type: textarea
     id: prior_art
     attributes:
       label: Prior art
-      description: List prior art—any relevant technical specifications, books, blog posts, conference talks from experts on the subject.
+      description: List any relevant technical specifications, books, blog posts, conference talks from experts on the subject.
   - type: textarea
     id: pros_cons
     attributes:
@@ -47,13 +46,11 @@ body:
     id: alternatives
     attributes:
       label: Alternatives
-      description: What are alternate proposals that may address the same problem? If this is not backwards compatible, what could a backwards compatible version look like? For each, describe why it’s not considered.
+      description: List out alternatives to your proposal. Why were they not considered? If this is not backwards compatible, what could a backwards compatible version look like?
   - type: checkboxes
     id: required_checks
     attributes:
       label: Required
       options:
-        - label: I have searched [existing issues](https://github.com/design-tokens/community-group/issues) and there is not already an open issue on the subject.
-          required: true
         - label: I have read and agree to abide by the [CODE_OF_CONDUCT](https://github.com/design-tokens/community-group/blob/CODE_OF_CONDUCT.md)
           required: true

--- a/.github/ISSUE_TEMPLATE/proposal.yml
+++ b/.github/ISSUE_TEMPLATE/proposal.yml
@@ -25,8 +25,6 @@ body:
     attributes:
       label: Problem & motivation
       description: In detail, what are the problem(s) you’re attempting to solve, either in your own design system or with the current specification syntax? List specific examples of how the current syntax doesn’t meet your needs.
-    validations:
-      required: true
   - type: textarea
     id: syntax
     attributes:
@@ -40,22 +38,16 @@ body:
     attributes:
       label: Prior art
       description: List prior art—any relevant technical specifications, books, blog posts, conference talks from experts on the subject.
-    validations:
-      required: true
   - type: textarea
     id: pros_cons
     attributes:
       label: Pros & cons
       description: What are the pros and cons of the change? If this is a backwards compatible change, list it as a “pro,” otherwise, list it as a “con.”
-    validations:
-      required: true
   - type: textarea
     id: alternatives
     attributes:
       label: Alternatives
       description: What are alternate proposals that may address the same problem? If this is not backwards compatible, what could a backwards compatible version look like? For each, describe why it’s not considered.
-    validations:
-      required: true
   - type: checkboxes
     id: required_checks
     attributes:

--- a/.github/ISSUE_TEMPLATE/proposal.yml
+++ b/.github/ISSUE_TEMPLATE/proposal.yml
@@ -1,0 +1,67 @@
+name: Proposal
+description: Suggest an addition or modification to the existing spec
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: Summarize your proposal in a few sentences.
+    validations:
+      required: true
+  - type: dropdown
+    id: versions
+    attributes:
+      label: Version
+      description: What version(s) of the spec are you using?
+      multiple: true
+      options:
+        - First Editor’s Draft
+        - Second Editor’s Draft
+        - Third Editor’s Draft
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem & motivation
+      description: In detail, what are the problem(s) you’re attempting to solve, either in your own design system or with the current specification syntax? List specific examples of how the current syntax doesn’t meet your needs.
+    validations:
+      required: true
+  - type: textarea
+    id: syntax
+    attributes:
+      label: Syntax
+      description: Describe the proposed syntax, in JSON format
+      render: json
+    validations:
+      required: true
+  - type: textarea
+    id: prior_art
+    attributes:
+      label: Prior art
+      description: List prior art—any relevant technical specifications, books, blog posts, conference talks from experts on the subject.
+    validations:
+      required: true
+  - type: textarea
+    id: pros_cons
+    attributes:
+      label: Pros & cons
+      description: What are the pros and cons of the change? If this is a backwards compatible change, list it as a “pro,” otherwise, list it as a “con.”
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives
+      description: What are alternate proposals that may address the same problem? If this is not backwards compatible, what could a backwards compatible version look like? For each, describe why it’s not considered.
+    validations:
+      required: true
+  - type: checkboxes
+    id: required_checks
+    attributes:
+      label: Required
+      options:
+        - label: I have searched [existing issues](https://github.com/design-tokens/community-group/issues) and there is not already an open issue on the subject.
+          required: true
+        - label: I have read and agree to abide by the [CODE_OF_CONDUCT](https://github.com/design-tokens/community-group/blob/CODE_OF_CONDUCT.md)
+          required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,7 @@
+## Changes
+
+_What does this PR change? Link to any related issue(s)._
+
+## How to Review
+
+_How can a reviewer review your changes? What should be kept in mind for this review?_


### PR DESCRIPTION
## Changes

### Issue templates

Adds 2 issue templates:

1. **Proposal**: Suggest an addition or modification to the spec. Requires folks to assemble a syntax proposal, and all necessary information
2. **Bug report**: Report a minor issue either in the spec, website, or elsewhere

Uses the new GitHub issue forms, so it is easy for newcomers to fill out: ![sample-issue-form](https://github.com/user-attachments/assets/0d37cdf0-1b18-4ddc-b193-01723203ba2c)

#### More info

These come from having worked on many open source repos, and managed quite a few. Having templates raises the quality bar for discussions, and **helps** newcomers contribute by having a clear guideline and simple form to fill out. It does take folks time, sure, but what takes even more time is figuring out what someone is talking about when they drop a few sentences into a textbox with no further detail.

### PR template

Also adds a PR template so it’s not blank.

## How to Review

- Check for typos
- Give feedback on verbiage! Nothing is set in stone