### PR TITLE
fix: spec typo

### DIFF
--- a/www/TR/second-editors-draft/format/index.html
+++ b/www/TR/second-editors-draft/format/index.html
@@ -1382,7 +1382,7 @@
   <ul>
   <li><code>duration</code>: The duration of the transition. The value of this property <em class="rfc2119">MUST</em> be a valid <a href="#duration">duration</a> value or a reference to a duration token.</li>
   <li><code>delay</code>: The time to wait before the transition begins. The value of this property <em class="rfc2119">MUST</em> be a valid <a href="#duration">duration</a> value or a reference to a duration token.</li>
-  <li><code>timingFunction</code>: The color of the shadow. The value of this property <em class="rfc2119">MUST</em> be a valid <a href="#cubic-bezier">cubic bézier</a> value or a reference to a cubic bézier token.</li>
+  <li><code>timingFunction</code>: The timing function of the transition. The value of this property <em class="rfc2119">MUST</em> be a valid <a href="#cubic-bezier">cubic bézier</a> value or a reference to a cubic bézier token.</li>
   </ul>
   <aside class="example" id="example-transition-composite-token-examples"><div class="marker">
       <a class="self-link" href="#example-transition-composite-token-examples">Example<bdi> 30</bdi></a><span class="example-title">: Transition composite token examples</span>


### PR DESCRIPTION
## Changes

Reapplies #264 to the Second Editors’ Draft. Fixes #227 once and for all

## How to Review

- Review changes
