### PR TITLE
chore: Format resolver spec into individual markdown files

### DIFF
--- a/technical-reports/format/index.html
+++ b/technical-reports/format/index.html
@@ -34,7 +34,6 @@
           { name: 'Matthew Ström', url: 'https://matthewstrom.com' },
           { name: 'Mike Kamminga', url: 'https://x.com/mikekamminga' },
         ],
-
         github: {
           repoURL: 'https://github.com/design-tokens/community-group',
           branch: 'main',

--- a/technical-reports/index.html
+++ b/technical-reports/index.html
@@ -72,7 +72,7 @@
           <a href="./format/">Format</a>
         </li>
         <li><a href="./color/">Color</a></li>
-        <li>Animations (coming soon)</li>
+        <li><a href="./resolver/">Resolver</a></li>
       </ul>
     </section>
     <section

--- a/technical-reports/resolver/CHANGELOG.md
+++ b/technical-reports/resolver/CHANGELOG.md
@@ -8,23 +8,23 @@ This release incorporates editorial improvements and community feedback summariz
 
 ### Added
 
--   **Resolution Aliasing Section:** Added a complete new section explaining aliasing/namespacing concepts with detailed examples and JSON Schema definition (from Working Copy)
--   **Community Feedback Integration:** Incorporated editorial comments and issues from the working copy document throughout the specification, highlighting ambiguities, inconsistencies, and areas needing clarification.
+- **Resolution Aliasing Section:** Added a complete new section explaining aliasing/namespacing concepts with detailed examples and JSON Schema definition (from Working Copy)
+- **Community Feedback Integration:** Incorporated editorial comments and issues from the working copy document throughout the specification, highlighting ambiguities, inconsistencies, and areas needing clarification.
 
 ### Issues Identified (from Working Copy)
 
--   **Terminology Clarifications:** Highlighted need for better definitions of "process", "inputs", "dimensions" vs "contexts", and disambiguation between different types of aliasing.
--   **File Extension Recommendations:** Suggested using `.tokens.json` extension to align with Design Tokens Format Specification conventions.
--   **Schema Structure Improvements:** Identified need to move functional properties out of generic `meta` property into formal schema definitions.
--   **Modifier Structure Concerns:** Raised questions about using arrays vs objects for modifiers to ensure uniqueness and prevent conflicts.
--   **Merging Logic Specification:** Highlighted need for detailed DTCG-compliant merging algorithms and conflict resolution rules.
--   **Precedence and Order:** Identified need for explicit precedence rules when multiple modifiers affect the same tokens.
--   **Orthogonality Declaration:** Suggested need for explicit orthogonality declarations to support lazy resolution.
+- **Terminology Clarifications:** Highlighted need for better definitions of "process", "inputs", "dimensions" vs "contexts", and disambiguation between different types of aliasing.
+- **File Extension Recommendations:** Suggested using `.tokens.json` extension to align with Design Tokens Format Specification conventions.
+- **Schema Structure Improvements:** Identified need to move functional properties out of generic `meta` property into formal schema definitions.
+- **Modifier Structure Concerns:** Raised questions about using arrays vs objects for modifiers to ensure uniqueness and prevent conflicts.
+- **Merging Logic Specification:** Highlighted need for detailed DTCG-compliant merging algorithms and conflict resolution rules.
+- **Precedence and Order:** Identified need for explicit precedence rules when multiple modifiers affect the same tokens.
+- **Orthogonality Declaration:** Suggested need for explicit orthogonality declarations to support lazy resolution.
 
 ### Notes
 
--   This version focuses on integrating community feedback and issue identification from the working copy rather than normative specification changes.
--   Issues summarized from the working copy will inform future specification development and clarifications.
+- This version focuses on integrating community feedback and issue identification from the working copy rather than normative specification changes.
+- Issues summarized from the working copy will inform future specification development and clarifications.
 
 ## [2.0.0] - 2023-10-27
 
@@ -32,19 +32,19 @@ This is the first major revision of the specification based on a detailed techni
 
 ### Added
 
--   **"Include" Modifier Type:** Added a new `include` type for modifiers, which is used to conditionally include a set of tokens. An example has been added to the "Modifiers" section.
--   **Order of Precedence:** A new subsection, "Order of Precedence," has been added to the "Resolution Logic" section to explicitly define the merge order for base sets and modifiers.
--   **Error Handling Guidance:** A new informative section, "Error Handling," has been added to recommend specific error types for common failure scenarios (e.g., `FileNotFoundError`, `CircularReferenceError`).
+- **"Include" Modifier Type:** Added a new `include` type for modifiers, which is used to conditionally include a set of tokens. An example has been added to the "Modifiers" section.
+- **Order of Precedence:** A new subsection, "Order of Precedence," has been added to the "Resolution Logic" section to explicitly define the merge order for base sets and modifiers.
+- **Error Handling Guidance:** A new informative section, "Error Handling," has been added to recommend specific error types for common failure scenarios (e.g., `FileNotFoundError`, `CircularReferenceError`).
 
 ### Changed
 
--   **Modifier Type:** The `type` property on modifiers now defaults to `"enumerated"`.
--   **Inline Token Definitions:** Clarified that an "inline token definition" must be a complete JSON object representing a valid token structure. An example has been added to the "Token Sets" section.
--   **Final Output Format:** The specification now explicitly states that the final resolved output should be a nested JSON object that mirrors the token paths, as shown in the examples.
--   **Path Resolution:** It is now explicitly stated that file paths in a resolver file must be resolved relative to the location of the resolver file itself.
--   **Alias Resolution Scope:** The spec now clarifies that alias resolution is performed on the fully merged set of tokens, allowing aliases to reference tokens across any loaded file.
--   **`meta.alias` Behavior:** The behavior of `meta.alias` is now more clearly defined, explaining that it namespaces the tokens from the modifier's files and that external references must use this namespace.
+- **Modifier Type:** The `type` property on modifiers now defaults to `"enumerated"`.
+- **Inline Token Definitions:** Clarified that an "inline token definition" must be a complete JSON object representing a valid token structure. An example has been added to the "Token Sets" section.
+- **Final Output Format:** The specification now explicitly states that the final resolved output should be a nested JSON object that mirrors the token paths, as shown in the examples.
+- **Path Resolution:** It is now explicitly stated that file paths in a resolver file must be resolved relative to the location of the resolver file itself.
+- **Alias Resolution Scope:** The spec now clarifies that alias resolution is performed on the fully merged set of tokens, allowing aliases to reference tokens across any loaded file.
+- **`meta.alias` Behavior:** The behavior of `meta.alias` is now more clearly defined, explaining that it namespaces the tokens from the modifier's files and that external references must use this namespace.
 
 ### Fixed
 
--   **Inconsistent `\$value` Key:** Corrected all instances of an inconsistent `value` key in JSON examples to use `\$value`, aligning with the Design Tokens Format Specification.
+- **Inconsistent `\$value` Key:** Corrected all instances of an inconsistent `value` key in JSON examples to use `\$value`, aligning with the Design Tokens Format Specification.

--- a/technical-reports/resolver/additional-context-and-information.md
+++ b/technical-reports/resolver/additional-context-and-information.md
@@ -1,0 +1,78 @@
+# Additional Context and Information
+
+## Resolution Aliasing
+
+Aliasing allows for dynamic namespacing or renaming of token paths during resolution. This is particularly useful when integrating external token sets or avoiding naming conflicts.
+
+</p>
+
+<aside class="example">
+
+Given a token set size.json:
+
+```json
+{
+  "sm": {
+    "value": "1px",
+    "type": "dimension"
+  },
+  "lg": {
+    "value": "10px",
+    "type": "dimension"
+  }
+}
+```
+
+By applying an alias in the modifier's meta.alias, we can namespace these tokens:
+
+```json
+{
+  "modifiers": [
+    {
+      "name": "size",
+      "type": "include",
+      "values": [
+        {
+          "name": "default",
+          "values": ["size.json"]
+        }
+      ],
+      "meta": {
+        "alias": "spacing"
+      }
+    }
+  ]
+}
+```
+
+Resulting in tokens accessible via spacing.sm and spacing.lg.
+
+</aside>
+
+<aside class="example">
+
+### Real-World Use Case: GitHub Primer
+
+The GitHub Primer design system uses multiple dimensions, including themes and visual modes (e.g., colorblind modes). The Resolver Specification can represent these dimensions as modifiers, allowing for efficient resolution and management of tokens.
+
+<aside class="ednote">
+
+Question: Would it be worth to highlight some public design systems and how they would use the resolver spec for more relatable use cases?
+
+</aside>
+
+</aside>
+
+<aside class="issue">
+
+While public design system examples could be valuable, generic use cases showing common dimensional patterns might be more important as foundational examples: single dimension (1 brand), two dimensions (1 brand + 2 themes), three dimensions (2 brands + 2 themes each), etc. These generic patterns would be the "meat and potatoes" compared to specific design system examples being the "cherry on the cake."
+
+</aside>
+
+## Orthogonality Considerations
+
+In scenarios where modifiers are not orthogonal, the resolver may need to enforce acceptable combinations and handle dependencies between modifiers. This can be achieved by:
+
+- Defining valid combinations explicitly.
+- Using nested modifiers or modifier groups.
+- Providing validation logic to prevent invalid input combinations.

--- a/technical-reports/resolver/conformance.md
+++ b/technical-reports/resolver/conformance.md
@@ -1,0 +1,7 @@
+Tools implementing the Resolver Specification MUST:
+
+- **Support the Resolution Process**: Implement the resolution logic as defined, including input validation, base set flattening, modifier application, aliasing, and conflict resolution.
+- **Validate Inputs**: Ensure that provided modifier inputs match the defined modifiers and acceptable values.
+- **Resolve Aliases Correctly**: Handle token references accurately, including recursive references and detection of circular dependencies.
+- **Preserve Token Properties**: Maintain additional token properties (e.g., description, type) throughout the resolution process.
+- **Handle Errors Gracefully**: Provide meaningful error messages for issues like invalid inputs or circular references.

--- a/technical-reports/resolver/example1.md
+++ b/technical-reports/resolver/example1.md
@@ -1,0 +1,290 @@
+# Example 1: Brand Theming
+
+<aside class="example">
+
+Scenario: A company has multiple brands—Brand A and Brand B. Each brand has its own color palette and typography. Components like buttons and headers need to adapt based on the selected brand.
+
+<aside class="issue">
+
+These examples could be moved to the Resolver Spec netlify app for better presentation. If it uses Astro, interactive code tabs could be added to make the examples more engaging and easier to understand through hands-on exploration.
+
+</aside>
+
+### Resolver Definition
+
+```json
+{
+  "name": "Brand Theming Resolver",
+  "sets": [
+    {
+      "name": "base",
+      "values": ["tokens/base.json"]
+    },
+    {
+      "values": ["tokens/components.json"]
+    }
+  ],
+  "modifiers": [
+    {
+      "name": "brand",
+      "type": "enumerated",
+      "values": [
+        {
+          "name": "brandA",
+          "values": ["tokens/brands/brandA.json"]
+        },
+        {
+          "name": "brandB",
+          "values": ["tokens/brands/brandB.json"]
+        }
+      ],
+      "meta": {
+        "default": "brandA",
+        "alias": "brand"
+      }
+    }
+  ]
+}
+```
+
+### Token Files</h3>
+
+#### tokens/base.json
+
+```json
+{
+  "color": {
+    "text": {
+      "primary": {
+        "value": "#000000",
+        "type": "color"
+      }
+    }
+  },
+  "font": {
+    "family": {
+      "default": {
+        "value": "Arial, sans-serif",
+        "type": "font"
+      }
+    }
+  }
+}
+```
+
+#### tokens/components.json
+
+```json
+{
+  "button": {
+    "background": {
+      "value": "{brand.color.primary}",
+      "type": "color"
+    },
+    "fontFamily": {
+      "value": "{brand.font.family}",
+      "type": "font"
+    }
+  },
+  "header": {
+    "color": {
+      "value": "{brand.color.secondary}",
+      "type": "color"
+    }
+  }
+}
+```
+
+#### tokens/brands/brandA.json
+
+```json
+{
+  "color": {
+    "primary": {
+      "value": "#FF5733",
+      "type": "color"
+    },
+    "secondary": {
+      "value": "#C70039",
+      "type": "color"
+    }
+  },
+  "font": {
+    "family": {
+      "value": "'Helvetica Neue', sans-serif",
+      "type": "font"
+    }
+  }
+}
+```
+
+#### tokens/brands/brandB.json
+
+```json
+{
+  "color": {
+    "primary": {
+      "value": "#1F618D",
+      "type": "color"
+    },
+    "secondary": {
+      "value": "#2874A6",
+      "type": "color"
+    }
+  },
+  "font": {
+    "family": {
+      "value": "'Times New Roman', serif",
+      "type": "font"
+    }
+  }
+}
+```
+
+### Input
+
+```json
+{
+  "brand": "brandB"
+}
+```
+
+### Resolution Steps<
+
+#### Input Validation
+
+- Confirm that "brand" is a defined modifier.
+- Verify that "brandB" is a valid value for the "brand" modifier.
+
+#### Base Set Flattening<
+
+Load tokens/base.json and tokens/components.json.
+
+Merge tokens:
+
+```json
+{
+  "color": {
+    "text": {
+      "primary": {
+        "value": "#000000",
+        "type": "color"
+      }
+    }
+  },
+  "font": {
+    "family": {
+      "default": {
+        "value": "Arial, sans-serif",
+        "type": "font"
+      }
+    }
+  },
+  "button": {
+    "background": {
+      "value": "{brand.color.primary}",
+      "type": "color"
+    },
+    "fontFamily": {
+      "value": "{brand.font.family}",
+      "type": "font"
+    }
+  },
+  "header": {
+    "color": {
+      "value": "{brand.color.secondary}",
+      "type": "color"
+    }
+  }
+}
+```
+
+#### Modifier Application
+
+Apply the "brand" modifier with value "brandB".
+
+Load tokens/brands/brandB.json.
+
+Apply aliasing as per meta.alias ("brand"), resulting in:
+
+```json
+{
+  "brand": {
+    "color": {
+      "primary": {
+        "value": "#1F618D",
+        "type": "color"
+      },
+      "secondary": {
+        "value": "#2874A6",
+        "type": "color"
+      }
+    },
+    "font": {
+      "family": {
+        "value": "'Times New Roman', serif",
+        "type": "font"
+      }
+    }
+  }
+}
+```
+
+#### Alias Resolution
+
+- Resolve {brand.color.primary} in button.background:
+  - Replace with #1F618D.
+- Resolve {brand.font.family} in button.fontFamily:
+  - Replace with 'Times New Roman', serif.
+- Resolve {brand.color.secondary} in header.color:
+  - Replace with #2874A6.
+
+#### Conflict Resolution
+
+No conflicts in this example.
+
+#### Final Output
+
+```json
+{
+  "color": {
+    "text": {
+      "primary": {
+        "value": "#000000",
+        "type": "color"
+      }
+    }
+  },
+  "font": {
+    "family": {
+      "default": {
+        "value": "Arial, sans-serif",
+        "type": "font"
+      }
+    }
+  },
+  "button": {
+    "background": {
+      "value": "#1F618D",
+      "type": "color"
+    },
+    "fontFamily": {
+      "value": "'Times New Roman', serif",
+      "type": "font"
+    }
+  },
+  "header": {
+    "color": {
+      "value": "#2874A6",
+      "type": "color"
+    }
+  }
+}
+```
+
+#### Explanation:
+
+- By changing the "brand" modifier, we can switch between different brand themes without altering the base token definitions.
+- The resolver efficiently manages the brand-specific overrides and applies them to components.
+
+</aside>

--- a/technical-reports/resolver/example2.md
+++ b/technical-reports/resolver/example2.md
@@ -1,0 +1,253 @@
+# Example 2: Component States
+
+<aside class="example" title="Responsive Design Resolver">
+
+Scenario: A design system includes buttons that change appearance based on their state—default, hover, active, and disabled. We want to manage these state-specific styles using modifiers.
+
+### Resolver Definition
+
+```json
+{
+  "name": "Component States Resolver",
+  "sets": [
+    {
+      "values": ["tokens/components/button.json"]
+    }
+  ],
+  "modifiers": [
+    {
+      "name": "state",
+      "type": "enumerated",
+      "values": [
+        {
+          "name": "default",
+          "values": ["tokens/states/default.json"]
+        },
+        {
+          "name": "hover",
+          "values": ["tokens/states/hover.json"]
+        },
+        {
+          "name": "active",
+          "values": ["tokens/states/active.json"]
+        },
+        {
+          "name": "disabled",
+          "values": ["tokens/states/disabled.json"]
+        }
+      ],
+      "meta": {
+        "default": "default"
+      }
+    }
+  ]
+}
+```
+
+### Token Files
+
+#### tokens/components/button.json
+
+```json
+{
+  "button": {
+    "background": {
+      "value": "{state.background}",
+      "type": "color"
+    },
+    "textColor": {
+      "value": "{state.textColor}",
+      "type": "color"
+    },
+    "borderColor": {
+      "value": "{state.borderColor}",
+      "type": "color"
+    }
+  }
+}
+```
+
+#### tokens/states/default.json
+
+```json
+{
+  "background": {
+    "value": "#FFFFFF",
+    "type": "color"
+  },
+  "textColor": {
+    "value": "#000000",
+    "type": "color"
+  },
+  "borderColor": {
+    "value": "#CCCCCC",
+    "type": "color"
+  }
+}
+```
+
+#### tokens/states/hover.json
+
+```json
+{
+  "background": {
+    "value": "#F0F0F0",
+    "type": "color"
+  },
+  "textColor": {
+    "value": "#000000",
+    "type": "color"
+  },
+  "borderColor": {
+    "value": "#BBBBBB",
+    "type": "color"
+  }
+}
+```
+
+#### tokens/states/active.json
+
+```json
+{
+  "background": {
+    "value": "#E0E0E0",
+    "type": "color"
+  },
+  "textColor": {
+    "value": "#000000",
+    "type": "color"
+  },
+  "borderColor": {
+    "value": "#AAAAAA",
+    "type": "color"
+  }
+}
+```
+
+#### tokens/states/disabled.json
+
+```json
+{
+  "background": {
+    "value": "#F9F9F9",
+    "type": "color"
+  },
+  "textColor": {
+    "value": "#777777",
+    "type": "color"
+  },
+  "borderColor": {
+    "value": "#DDDDDD",
+    "type": "color"
+  }
+}
+```
+
+### Input
+
+```json
+{
+  "state": "hover"
+}
+```
+
+### Resolution Steps
+
+#### Input Validation
+
+- Confirm that "state" is a defined modifier.
+- Verify that "hover" is a valid value for the "state" modifier.
+
+#### Base Set Flattening
+
+Load tokens/components/button.json.
+
+Tokens:
+
+```json
+{
+  "button": {
+    "background": {
+      "value": "{state.background}",
+      "type": "color"
+    },
+    "textColor": {
+      "value": "{state.textColor}",
+      "type": "color"
+    },
+    "borderColor": {
+      "value": "{state.borderColor}",
+      "type": "color"
+    }
+  }
+}
+```
+
+#### Modifier Application
+
+Apply the "state" modifier with value "hover".
+
+Load tokens/states/hover.json.
+
+Tokens under the "state" namespace:
+
+```json
+{
+  "state": {
+    "background": {
+      "value": "#F0F0F0",
+      "type": "color"
+    },
+    "textColor": {
+      "value": "#000000",
+      "type": "color"
+    },
+    "borderColor": {
+      "value": "#BBBBBB",
+      "type": "color"
+    }
+  }
+}
+```
+
+#### Alias Resolution
+
+- Resolve {state.background} in button.background:
+  - Replace with #F0F0F0.
+- Resolve {state.textColor} in button.textColor:
+  - Replace with #000000.
+- Resolve {state.borderColor} in button.borderColor:
+  - Replace with #BBBBBB.
+
+#### Conflict Resolution
+
+No conflicts in this example.
+
+#### Final Output
+
+```json
+{
+  "button": {
+    "background": {
+      "value": "#F0F0F0",
+      "type": "color"
+    },
+    "textColor": {
+      "value": "#000000",
+      "type": "color"
+    },
+    "borderColor": {
+      "value": "#BBBBBB",
+      "type": "color"
+    }
+  }
+}
+```
+
+#### Explanation:
+
+- By changing the "state" modifier, we can easily generate the tokens for different button states.
+
+- This approach keeps state-specific styles organized and separate from component definitions.
+
+</aside>

--- a/technical-reports/resolver/example3.md
+++ b/technical-reports/resolver/example3.md
@@ -1,0 +1,283 @@
+# Example 3: Responsive Design
+
+<aside class="example" title="Responsive Design Resolver">
+
+Scenario: A design system needs to support responsive design by adjusting spacing and typography based on screen sizes—mobile, tablet, and desktop. We want to manage these variations using modifiers.
+
+### Resolver Definition
+
+```json
+{
+  "name": "Responsive Design Resolver",
+  "sets": [
+    {
+      "name": "core",
+      "values": ["tokens/core.json"]
+    }
+  ],
+  "modifiers": [
+    {
+      "name": "screenSize",
+      "type": "enumerated",
+      "values": [
+        {
+          "name": "mobile",
+          "values": ["tokens/screens/mobile.json"]
+        },
+        {
+          "name": "tablet",
+          "values": ["tokens/screens/tablet.json"]
+        },
+        {
+          "name": "desktop",
+          "values": ["tokens/screens/desktop.json"]
+        }
+      ],
+      "meta": {
+        "default": "mobile",
+        "alias": "screen"
+      }
+    }
+  ]
+}
+```
+
+### Token Files
+
+#### tokens/core.json
+
+```json
+{
+  "spacing": {
+    "small": {
+      "value": "{screen.spacing.small}",
+      "type": "dimension"
+    },
+    "medium": {
+      "value": "{screen.spacing.medium}",
+      "type": "dimension"
+    },
+    "large": {
+      "value": "{screen.spacing.large}",
+      "type": "dimension"
+    }
+  },
+  "typography": {
+    "fontSize": {
+      "value": "{screen.typography.fontSize}",
+      "type": "dimension"
+    }
+  }
+}
+```
+
+#### tokens/screens/mobile.json
+
+```json
+{
+  "spacing": {
+    "small": {
+      "value": "4px",
+      "type": "dimension"
+    },
+    "medium": {
+      "value": "8px",
+      "type": "dimension"
+    },
+    "large": {
+      "value": "12px",
+      "type": "dimension"
+    }
+  },
+  "typography": {
+    "fontSize": {
+      "value": "14px",
+      "type": "dimension"
+    }
+  }
+}
+```
+
+#### tokens/screens/tablet.json
+
+```json
+{
+  "spacing": {
+    "small": {
+      "value": "6px",
+      "type": "dimension"
+    },
+    "medium": {
+      "value": "12px",
+      "type": "dimension"
+    },
+    "large": {
+      "value": "18px",
+      "type": "dimension"
+    }
+  },
+  "typography": {
+    "fontSize": {
+      "value": "16px",
+      "type": "dimension"
+    }
+  }
+}
+```
+
+#### tokens/screens/desktop.json
+
+```json
+{
+  "spacing": {
+    "small": {
+      "value": "8px",
+      "type": "dimension"
+    },
+    "medium": {
+      "value": "16px",
+      "type": "dimension"
+    },
+    "large": {
+      "value": "24px",
+      "type": "dimension"
+    }
+  },
+  "typography": {
+    "fontSize": {
+      "value": "18px",
+      "type": "dimension"
+    }
+  }
+}
+```
+
+### Input
+
+```json
+{
+  "screenSize": "desktop"
+}
+```
+
+### Resolution Steps
+
+#### Input Validation<
+
+- Confirm that "screenSize" is a defined modifier.
+- Verify that "desktop" is a valid value for the "screenSize" modifier.
+
+#### Base Set Flattening<
+
+Load tokens/core.json.
+
+Tokens:
+
+```json
+{
+  "spacing": {
+    "small": {
+      "value": "{screen.spacing.small}",
+      "type": "dimension"
+    },
+    "medium": {
+      "value": "{screen.spacing.medium}",
+      "type": "dimension"
+    },
+    "large": {
+      "value": "{screen.spacing.large}",
+      "type": "dimension"
+    }
+  },
+  "typography": {
+    "fontSize": {
+      "value": "{screen.typography.fontSize}",
+      "type": "dimension"
+    }
+  }
+}
+```
+
+#### Modifier Application
+
+Apply the "screenSize" modifier with value "desktop".
+
+Load tokens/screens/desktop.json.
+
+Apply aliasing as per meta.alias ("screen"), resulting in:
+
+```json
+{
+  "screen": {
+    "spacing": {
+      "small": {
+        "value": "8px",
+        "type": "dimension"
+      },
+      "medium": {
+        "value": "16px",
+        "type": "dimension"
+      },
+      "large": {
+        "value": "24px",
+        "type": "dimension"
+      }
+    },
+    "typography": {
+      "fontSize": {
+        "value": "18px",
+        "type": "dimension"
+      }
+    }
+  }
+}
+```
+
+#### Alias Resolution
+
+- Resolve {screen.spacing.small} in spacing.small:
+  - Replace with 8px.
+- Resolve {screen.spacing.medium} in spacing.medium:
+  - Replace with 16px.
+- Resolve {screen.spacing.large} in spacing.large:
+  - Replace with 24px.
+- Resolve {screen.typography.fontSize} in typography.fontSize:
+  - Replace with 18px.
+
+#### Conflict Resolution
+
+No conflicts in this example.
+
+#### Final Output
+
+```json
+{
+  "spacing": {
+    "small": {
+      "value": "8px",
+      "type": "dimension"
+    },
+    "medium": {
+      "value": "16px",
+      "type": "dimension"
+    },
+    "large": {
+      "value": "24px",
+      "type": "dimension"
+    }
+  },
+  "typography": {
+    "fontSize": {
+      "value": "18px",
+      "type": "dimension"
+    }
+  }
+}
+```
+
+#### Explanation:
+
+- By changing the "screenSize" modifier, we can generate tokens appropriate for different devices.
+- This method centralizes responsive adjustments, making it easier to maintain and update.
+
+</aside>

--- a/technical-reports/resolver/file-format.md
+++ b/technical-reports/resolver/file-format.md
@@ -1,0 +1,127 @@
+# File Format
+
+A resolver is defined as a JSON object with the following properties:
+
+- **name** (optional): A human-readable name for the resolver.
+- **description** (optional): A description of the resolver's purpose.
+- **sets** (required): An array of token sets to be used as the base for resolution.
+- **modifiers** (optional): An array of modifiers that can alter or override tokens from the base sets.
+
+### Token Sets
+
+Each token set in the **sets** array is an object with the following properties:
+
+- **name** (optional): An identifier for the set.
+- **values** (required): An array of references to token files or inline token definitions. A reference MUST be a string containing a path to a token file. An inline token definition MUST be a JSON object containing a valid design token structure.
+- **meta** (optional): Additional metadata, such as proprietary extensions.
+
+<aside class="example" title="Token Set">
+
+```json
+{
+  "sets": [
+    {
+      "name": "foundation",
+      "values": ["foundation.json"]
+    },
+    {
+      "values": [
+        "components/button.json",
+        {
+          "inline-token": { "$value": "some-value" }
+        }
+      ]
+    }
+  ]
+}
+```
+
+</aside>
+
+<aside class="issue">
+
+It is recommended to use `.tokens.json` as the file extension for token files to align with the Design Tokens Format Specification naming conventions. This helps reinforce that these files should contain valid DTCG token structures rather than arbitrary JSON data.
+
+</aside>
+
+### Modifiers
+
+Modifiers are defined in the **modifiers** array and can have different types, affecting how they influence the resolution
+process.
+
+Each modifier is an object with the following properties:
+
+- **name** (required): The name of the modifier.
+- **type** (optional, default: "enumerated"): The type of modifier. This can be "enumerated" or "include".
+- **values** (required): An array of possible values for the modifier.
+- **meta** (optional): Additional metadata, such as default values or aliases.
+
+<aside class="issue">
+
+Default values and aliasing should be moved out of the generic `meta` property into specific typed properties. The `meta` property should be reserved for implementation-specific extensions rather than functionality that directly contributes to resolution behavior.
+
+</aside>
+
+<aside class="example" title="Enumerated modifier">
+
+```json
+{
+  "modifiers": [
+    {
+      "name": "theme",
+      "type": "enumerated",
+      "values": [
+        {
+          "name": "light",
+          "values": ["themes/light.json"]
+        },
+        {
+          "name": "dark",
+          "values": ["themes/dark.json"]
+        }
+      ],
+      "meta": {
+        "default": "light",
+        "alias": "theme"
+      }
+    }
+  ]
+}
+```
+
+</aside>
+
+<aside class="issue">
+
+There are structural problems with using arrays for modifiers and their values. Since `name` is required and must be unique for proper resolution, arrays allow for multiple conflicting values which should be impossible. For example, if a user passes `{ theme: "dark" }` and there are 2 modifiers named "theme" and 2 modifier values named "dark", this creates ambiguity that should be an error rather than defaulting to "take the first one." While arrays make sense for defining order of application, if we want key-value mapping for applying modifiers, flat objects should be required to ensure unique IDs by design.
+
+</aside>
+
+<aside class="issue">
+
+The specification needs to clarify what constitutes valid values in the `values` array for modifiers. Key questions include: Are only relative pathnames allowed? Can referenced files have sets/modifiers of their own (enabling resolver chaining)? Should there be support for referencing sets by name (e.g., "foundation") rather than repeating file paths? The concept of chaining resolvers could use different type values to identify other resolvers. Additionally, values could support local references starting with "#" or string references to set names, making it easier to reference entire sets without listing all token file paths.
+
+</aside>
+
+<aside class="example" title="Include modifier">
+
+This type of modifier is used to conditionally include a set of tokens. The `values` array for an include modifier contains objects with a `name` and a corresponding list of `values` (file paths or inline tokens) that will be included if that name is present in the input.
+
+```json
+{
+  "modifiers": [
+    {
+      "name": "features",
+      "type": "include",
+      "values": [
+        {
+          "name": "experimental-feature-x",
+          "values": ["features/feature-x.json"]
+        }
+      ]
+    }
+  ]
+}
+```
+
+</aside>

--- a/technical-reports/resolver/future-extensions.md
+++ b/technical-reports/resolver/future-extensions.md
@@ -1,0 +1,7 @@
+# Future Extensions
+
+The Resolver Specification can be extended to handle more complex scenarios:
+
+- **Conditional Modifiers**: Modifiers that are applied based on conditions or contexts not specified directly in the input.
+- **Dynamic Resolution**: Support for runtime evaluation of tokens based on environmental factors (e.g., screen size, user preferences).
+- **Dependency Graphs**: Explicitly defining dependencies between modifiers to handle non-orthogonal scenarios.

--- a/technical-reports/resolver/index.html
+++ b/technical-reports/resolver/index.html
@@ -1,1627 +1,181 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
     <title>Design Tokens Resolver Module</title>
-    <script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
+    <script
+      src="https://www.w3.org/Tools/respec/respec-w3c"
+      class="remove"
+    ></script>
     <script class="remove">
       var respecConfig = {
-        specStatus: "CG-DRAFT",
+        specStatus: 'CG-DRAFT',
+        group: 'design-tokens',
+        // In PR preview apps, shows an annoying red box to the document,
+        // warning unsuspecting readers that they should not cite or
+        // reference this version of the specification.
+        isPreview: document.location.host.includes('preview'),
         editors: [
-          { name: "Andrew L'Homme", email: "andrew@hyma.io" },
-          { name: "Drew Powers" },
-          { name: "Esther Cheran", email: "esther@hyma.io" },
-          { name: "James Nash" },
-          { name: "Joren Broekema", email: "joren@hyma.io" },
-          { name: "Louis Chenais" },
-          { name: "Mike Kamminga", email: "mike@hyma.io" },
+          { name: "Andrew L'Homme", email: 'andrew@hyma.io' },
+          { name: 'Drew Powers' },
+          { name: 'Esther Cheran', email: 'esther@hyma.io' },
+          { name: 'James Nash' },
+          { name: 'Joren Broekema', email: 'joren@hyma.io' },
+          { name: 'Louis Chenais' },
+          { name: 'Mike Kamminga', email: 'mike@hyma.io' },
         ],
-        shortName: "design-tokens-resolvers",
-        cg: "Design Tokens W3C Community Group",
-        cgURI: "https://github.com/design-tokens/community-group",
+        shortName: 'design-tokens-resolvers',
+        cg: 'Design Tokens W3C Community Group',
+        cgURI: 'https://github.com/design-tokens/community-group',
         github: {
-          repoURL: "https://github.com/design-tokens/community-group",
-          branch: "main",
+          repoURL: 'https://github.com/design-tokens/community-group',
+          branch: 'main',
         },
+        tocIntroductory: true,
+        logos: [
+          {
+            src: '/_includes/assets/images/logo_128_2x.png',
+            url: 'https://www.designtokens.org',
+            alt: 'Design Tokens Community Group',
+            width: 128,
+            height: 128,
+            id: 'dtcg-logo',
+          },
+        ],
       };
     </script>
   </head>
   <body>
     <section id="abstract">
       <p>
-        This document describes the technical specification for a resolver mechanism used to manage and resolve design tokens in complex scenarios involving themes, modes, brands, and other modifiers. It extends the Design Tokens Format Specification by introducing a structured way to combine and override token sets to produce a final, resolved set of tokens for consumption by design tools and platforms.
+        This document describes the technical specification for a resolver
+        mechanism used to manage and resolve design tokens in complex scenarios
+        involving themes, modes, brands, and other modifiers. It extends the
+        Design Tokens Format Specification by introducing a structured way to
+        combine and override token sets to produce a final, resolved set of
+        tokens for consumption by design tools and platforms.
       </p>
     </section>
 
     <section id="sotd">
       <p>
-        This is a snapshot of the editors’ draft. It is provided for discussion only and may change at any moment. Its publication here does not imply endorsement of its contents by W3C or the Design Tokens W3C Community Group Membership. Don’t cite this document other than as work in progress.
+        This is a snapshot of the editors’ draft. It is provided for discussion
+        only and may change at any moment. Its publication here does not imply
+        endorsement of its contents by W3C or the Design Tokens W3C Community
+        Group Membership. Don’t cite this document other than as work in
+        progress.
       </p>
+      <p>This document has been published to facilitate Wide Review.</p>
       <p>
-        This document has been published to facilitate Wide Review.
-      </p>
-      <p>
-        This document was produced by the Design Tokens W3C Community Group, and contributions to this draft are governed by <a href="https://www.w3.org/community/about/process/cla">Community Contributor License Agreement (CLA)</a>, as specified by the <a href="https://www.w3.org/community/about/process/#cgroups">W3C Community Group Process</a>.
-      </p>
-    </section>
-
-    <section class="informative">
-      <h2>Introduction</h2>
-      <p>
-        Design tokens are key-value pairs that represent design decisions, allowing for consistent use across different platforms and tools. In complex design systems, there is a need to manage multiple dimensions such as themes, modes (e.g., light and dark), brands, and variants. This introduces challenges in organizing tokens, resolving references, and applying overrides.
-      </p>
-      <p>
-        The Resolver Specification addresses these challenges by introducing a structured mechanism to:
-      </p>
-      <ul>
-        <li>Organize tokens into <strong>sets</strong> and <strong>modifiers</strong>.</li>
-        <li>Define how tokens are <strong>resolved</strong> when multiple sets and modifiers are involved.</li>
-        <li>Support <strong>scalability</strong> by handling arbitrary dimensions without complicating the core token definitions.</li>
-        <li>Maintain <strong>modularity</strong> and <strong>reusability</strong> by allowing tokens to be combined and overridden in a controlled manner.</li>
-      </ul>
-    </section>
-
-    <section class="informative">
-      <h2>Rationale</h2>
-      <section>
-        <h3>Context and Problem Statement</h3>
-        <p>In design systems, especially those at scale, managing multiple themes, modes, brands, and other modifiers can become complex. Designers and developers often struggle with:</p>
-        <ul>
-          <li><strong>Naming Conflicts</strong>: Using complex naming conventions to differentiate tokens across different themes or modes, leading to brittle and hard-to-maintain token names.</li>
-          <li><strong>Scalability Issues</strong>: Difficulty in scaling token management when new dimensions are added, such as additional themes or brands.</li>
-          <li><strong>Tooling Limitations</strong>: Existing tools may not support multi-dimensional token resolution, forcing teams to create workarounds that complicate their workflows.</li>
-          <li><strong>Separation of Concerns</strong>: Embedding resolution logic within token files mixes data with behavior, violating separation of concerns.</li>
-        </ul>
-      </section>
-      <section>
-        <h3>Parameters</h3>
-        <ul>
-          <li><strong>Simplicity</strong>: The solution should keep token files simple and editable by hand, without requiring complex tooling.</li>
-          <li><strong>Scalability</strong>: It should support arbitrary dimensions (e.g., themes, modes, brands) without significant overhead.</li>
-          <li><strong>Modularity</strong>: Tokens should be organized in a way that allows for modularity and reusability.</li>
-          <li><strong>Separation of Concerns</strong>: Resolution logic should be externalized from token definitions.</li>
-        </ul>
-      </section>
-      <section>
-        <h3>Background</h3>
-        <p>Existing approaches, such as embedding modifiers directly into token names or using global theme files, have limitations. They often lead to:</p>
-        <ul>
-          <li><strong>Global Namespace Pollution</strong>: All tokens exist in a single global namespace, increasing the likelihood of naming conflicts.</li>
-          <li><strong>High Cognitive Load</strong>: Designers and developers must remember complex naming conventions and how different tokens relate across dimensions.</li>
-          <li><strong>Performance Issues</strong>: Resolving tokens in systems with many dimensions can be slow due to the combinatorial explosion of permutations.</li>
-        </ul>
-      </section>
-      <section>
-        <h3>Motivation</h3>
-        <p>The Resolver Specification aims to:</p>
-        <ul>
-          <li><strong>Simplify Token Management</strong>: By externalizing resolution logic, token files remain simple and focused on defining values.</li>
-          <li><strong>Enhance Modularity</strong>: Tokens can be organized into sets and modifiers, allowing teams to work on isolated components or themes without affecting others.</li>
-          <li><strong>Improve Performance</strong>: By reducing the scope of tokens in resolution, the process becomes faster and more efficient.</li>
-          <p class="issue">
-            The term "process" needs clarification - what specific process is being referred to? Is this the "resolution process of the resolver"? More explanation is needed to understand exactly what becomes faster and more efficient when token scope is reduced during resolution.
-          </p>
-          <li><strong>Facilitate Tool Integration</strong>: Providing a standard way to define resolution logic makes it easier for tools to integrate and automate token management.</li>
-        </ul>
-              </section>
-      </section>
-
-    <p class="issue">
-      A side effect of using a resolver should be the ability to have a clear dependency graph of how a resolution request would occur purely based on the inputs. This would enable better understanding of modifier interactions and support more efficient resolution strategies.
-    </p>
-
-    <section>
-      <h2>Resolver Terminology</h2>
-      <dl>
-        <dt>Resolver</dt>
-        <dd>A mechanism that combines token sets and applies modifiers to produce a final, resolved set of design tokens.</dd>
-        <dt>Token Set</dt>
-        <dd>A collection of design tokens grouped together, often representing foundational tokens, component-specific tokens, or theme-specific tokens.</dd>
-        <dt> Dimension</dt>
-        <dd>Dimensions are categories used to organize your design tokens. See them as contexts in which token values might change:</dd>
-        <ul>
-          <li>Brands</li>
-          <li>Surface</li>
-          <li>Language direction</li>
-          <li>Themes</li>
-          <li>Platform</li>
-          <li>Screen size</li>
-          <li>Density</li>
-          <li>Component</li>
-          <li>State</li>
-          <li>Variant</li>
-          <li>Contrast</li>
-        </ul>
-        <p class="issue">
-          The term "Dimension" is potentially confusing since "Dimension" is also a type of token and a general concept. Consider using "Context" instead, which aligns with the existing definition as "contexts in which token values might change." Additionally, explicit mention of color schemes may be problematic - developers often distinguish between "themes" and "color modes" (like Windows High Contrast mode for accessibility), and it's unclear whether everyone would understand themes to encompass dark/light/high-contrast modes.
-        </p>
-        <dt>Modifier</dt>
-        <dd>
-          An entity that modifies or overrides tokens in the base sets. Modifiers can represent dimensions like themes, modes, brands, or any other contextual variations.
-          <dl>
-            <dt>Enumerated Modifier</dt>
-            <dd>A modifier with predefined, named values (e.g., "light", "dark" for a theme modifier).</dd>
-            <dt>Include Modifier</dt>
-            <dd>A modifier that replaces or includes entire token sets during resolution.</dd>
-            <dt>Alias</dt>
-            <dd>An optional property that allows for namespacing or renaming token paths during resolution.</dd>
-          </dl>
-          <p class="issue">
-            The modifier types and their behaviors aren't clear from these definitions alone. Real-world examples showing how Enumerated Modifiers, Include Modifiers, and Alias properties work in practice would help clarify their purpose and usage.
-          </p>
-        </dd>
-        <dt>Input</dt>
-        <dd>Parameters provided to the resolver to specify which modifiers to apply during the resolution process.</dd>
-        <dt>Resolution</dt>
-        <dd>The process of combining token sets and applying modifiers based on the specified inputs to produce the final set of tokens.</dd>
-        <p class="issue">
-          The specification should address different real-world resolution use cases and their performance implications: <strong>full upfront resolution</strong> (resolving all possible combinations ahead of time), <strong>lazy resolution</strong> (resolving on-demand), and <strong>partial resolution</strong> for complex components. Without being upfront about token combinations and scopes, systems face combinatorial explosion problems that make resolution inefficient. There may be significant performance aspects to consider, especially for JIT (Just-In-Time) resolution scenarios. Input from tool makers like Figma and other design platforms would be valuable to understand real-world performance requirements and constraints.
-        </p>
-        <dt>Orthogonality</dt>
-        <dd>The property of modifiers being independent of each other, allowing them to be combined freely without affecting each other's resolution logic.</dd>
-      </dl>
-    </section>
-
-    <section>
-      <h2>Resolver File Format</h2>
-      <p>A resolver is defined as a JSON object with the following properties:</p>
-      <ul>
-        <li><strong>name</strong> (optional): A human-readable name for the resolver.</li>
-        <li><strong>description</strong> (optional): A description of the resolver's purpose.</li>
-        <li><strong>sets</strong> (required): An array of token sets to be used as the base for resolution.</li>
-        <li><strong>modifiers</strong> (optional): An array of modifiers that can alter or override tokens from the base sets.</li>
-      </ul>
-
-      <section>
-        <h3>Token Sets</h3>
-        <p>Each token set in the <strong>sets</strong> array is an object with the following properties:</p>
-        <ul>
-          <li><strong>name</strong> (optional): An identifier for the set.</li>
-          <li><strong>values</strong> (required): An array of references to token files or inline token definitions. A reference <em class="rfc2119">MUST</em> be a string containing a path to a token file. An inline token definition <em class="rfc2119">MUST</em> be a JSON object containing a valid design token structure.</li>
-          <li><strong>meta</strong> (optional): Additional metadata, such as proprietary extensions.</li>
-        </ul>
-        <p>Example:</p>
-        <pre class="example json" title="Token Set Example">
-{
-  "sets": [
-    {
-      "name": "foundation",
-      "values": ["foundation.json"]
-    },
-    {
-      "values": [
-        "components/button.json",
-        {
-          "inline-token": { "$value": "some-value" }
-        }
-      ]
-    }
-  ]
-}
-        </pre>
-        <p class="issue">
-          It is recommended to use <code>.tokens.json</code> as the file extension for token files to align with the Design Tokens Format Specification naming conventions. This helps reinforce that these files should contain valid DTCG token structures rather than arbitrary JSON data.
-        </p>
-      </section>
-
-      <section>
-        <h3>Modifiers</h3>
-        <p>Modifiers are defined in the <strong>modifiers</strong> array and can have different types, affecting how they influence the resolution process.</p>
-        <p>Each modifier is an object with the following properties:</p>
-        <ul>
-          <li><strong>name</strong> (required): The name of the modifier.</li>
-          <li><strong>type</strong> (optional, default: "enumerated"): The type of modifier. This can be "enumerated" or "include".</li>
-          <li><strong>values</strong> (required): An array of possible values for the modifier.</li>
-          <li><strong>meta</strong> (optional): Additional metadata, such as default values or aliases.</li>
-        </ul>
-        <p class="issue">
-          Default values and aliasing should be moved out of the generic <code>meta</code> property into specific typed properties. The <code>meta</code> property should be reserved for implementation-specific extensions rather than functionality that directly contributes to resolution behavior.
-        </p>
-        <p>Example of an "enumerated" modifier:</p>
-        <pre class="example json" title="Enumerated Modifier Example">
-{
-  "modifiers": [
-    {
-      "name": "theme",
-      "type": "enumerated",
-      "values": [
-        {
-          "name": "light",
-          "values": ["themes/light.json"]
-        },
-        {
-          "name": "dark",
-          "values": ["themes/dark.json"]
-        }
-      ],
-      "meta": {
-        "default": "light",
-        "alias": "theme"
-      }
-    }
-  ]
-}
-        </pre>
-        <p class="issue">
-          There are structural problems with using arrays for modifiers and their values. Since <code>name</code> is required and must be unique for proper resolution, arrays allow for multiple conflicting values which should be impossible. For example, if a user passes <code>{ theme: "dark" }</code> and there are 2 modifiers named "theme" and 2 modifier values named "dark", this creates ambiguity that should be an error rather than defaulting to "take the first one." While arrays make sense for defining order of application, if we want key-value mapping for applying modifiers, flat objects should be required to ensure unique IDs by design.
-        </p>
-        <p class="issue">
-          The specification needs to clarify what constitutes valid values in the <code>values</code> array for modifiers. Key questions include: Are only relative pathnames allowed? Can referenced files have sets/modifiers of their own (enabling resolver chaining)? Should there be support for referencing sets by name (e.g., "foundation") rather than repeating file paths? The concept of chaining resolvers could use different type values to identify other resolvers. Additionally, values could support local references starting with "#" or string references to set names, making it easier to reference entire sets without listing all token file paths.
-        </p>
-        
-        <p>Example of an "include" modifier. This type of modifier is used to conditionally include a set of tokens. The `values` array for an include modifier contains objects with a `name` and a corresponding list of `values` (file paths or inline tokens) that will be included if that name is present in the input.</p>
-        <pre class="example json" title="Include Modifier Example">
-{
-  "modifiers": [
-    {
-      "name": "features",
-      "type": "include",
-      "values": [
-        {
-          "name": "experimental-feature-x",
-          "values": ["features/feature-x.json"]
-        }
-      ]
-    }
-  ]
-}
-        </pre>
-      </section>
-    </section>
-
-    <section>
-      <h2>Resolution Aliasing</h2>
-      <p>Aliasing allows for dynamic namespacing or renaming of token paths during resolution. This is particularly useful when integrating external token sets or avoiding naming conflicts.</p>
-      <div class="issue">
-        <p><strong>Namespace vs Alias Terminology:</strong> Should the <code>alias</code> property be renamed to <code>namespace</code> to avoid confusion with token aliases (references to other tokens)?</p>
-        <p><strong>Redundancy with Modifier Names:</strong> The <code>meta.alias</code> property may be redundant since modifiers already have a <code>name</code> property that could serve the same namespacing purpose.</p>
-        <p><strong>Auto-namespacing Concerns:</strong> The automatic application of namespacing for modifiers introduces significant complexity and potential issues:</p>
-        <ul>
-          <li>Requires pre-resolution conflict checking across all sets and modifiers</li>
-          <li>Modifier JSON must be complete sets to avoid undefined token references</li>
-          <li>Risk of infinite loops if modifiers reference tokens in other modifier namespaces</li>
-          <li>Backwards compatibility issues requiring extensive token renames in existing design systems</li>
-        </ul>
-        <p><strong>Alternative Approach:</strong> Consider removing auto-namespacing for modifiers and using shared merging logic between sets and modifiers for better compatibility and simplicity.</p>
-      </div>
-      <p><strong>Example:</strong></p>
-      <p>Given a token set size.json:</p>
-      <pre class="example json" title="size.json">
-{
-  "sm": {
-    "value": "1px",
-    "type": "dimension"
-  },
-  "lg": {
-    "value": "10px",
-    "type": "dimension"
-  }
-}
-      </pre>
-      <p>By applying an alias in the modifier's meta.alias, we can namespace these tokens:</p>
-      <pre class="example json" title="Aliased Modifier">
-{
-  "modifiers": [
-    {
-      "name": "size",
-      "type": "include",
-      "values": [
-        {
-          "name": "default",
-          "values": ["size.json"]
-        }
-      ],
-      "meta": {
-        "alias": "spacing"
-      }
-    }
-  ]
-}
-      </pre>
-             <p>Resulting in tokens accessible via spacing.sm and spacing.lg.</p>
-             <p class="issue">
-               If the <code>meta.alias</code> behavior described above is normative/required behavior, it should not be part of the generic <code>meta</code> property but should be defined as part of the formal schema. Alternatively, if this is just an example of tooling-specific behavior, it should be clearly called out as such and not presented as part of the core specification.
-             </p>
-       
-       <section>
-         <h3>JSON Schema</h3>
-         <p>Source: <a href="https://resolver-spec.netlify.app/reference/schema/">https://resolver-spec.netlify.app/reference/schema/</a></p>
-         <pre class="example json" title="Resolver JSON Schema">
-{
-  "$id": "https://schemas.tokens.studio/prototype/resolver.json",
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "description": "Resolver Specification",
-  "$defs": {
-    "tokenSet": {
-      "type": "object",
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "values": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      },
-      "required": ["values"]
-    },
-    "modifier": {
-      "type": "object",
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "values": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "properties": {
-              "name": {
-                "type": "string"
-              },
-              "values": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              }
-            },
-            "required": ["name", "values"]
-          }
-        },
-        "meta": {
-          "type": "object",
-          "additionalProperties": true
-        }
-      },
-      "required": ["name", "values"]
-    }
-  },
-  "type": "object",
-  "properties": {
-    "name": {
-      "type": "string"
-    },
-    "description": {
-      "type": "string"
-    },
-    "sets": {
-      "type": "array",
-      "items": {
-        "$ref": "#/$defs/tokenSet"
-      }
-    },
-    "modifiers": {
-      "type": "array",
-      "items": {
-        "$ref": "#/$defs/modifier"
-      }
-    }
-  },
-  "required": ["sets", "modifiers"]
-}
-         </pre>
-       </section>
-    </section>
-
-    <section>
-      <h2>Resolution Logic</h2>
-      <p>The resolution process involves the following steps:</p>
-      <ol>
-        <li><strong>Input Validation</strong>: Ensure the provided inputs match the expected modifiers and their acceptable values.</li>
-        <p class="issue">
-          The term "inputs" is used throughout the specification but never formally defined. Inputs appear to represent the permutation or combination of modifiers being selected for resolution - essentially the question "What would my output look like given some combination of modifiers being enabled or chosen?" This fundamental concept should be clearly defined, potentially as "data" or with a more specific term that clarifies its role in the resolution process.
-        </p>
-        <li><strong>Base Set Flattening</strong>: Load and merge the token sets specified in the <strong>sets</strong> array. Later sets override earlier ones if there are naming conflicts.</li>
-        <p class="issue">
-          The merging process needs detailed specification to handle DTCG token data correctly. Simply performing a deep merge on raw JSON could yield different results than fully interpreting the DTCG data first and then merging. This is particularly important for inheritable format properties like <code>$type</code>. For example, when loading two JSON files with a top-level "color" key where one has <code>$type: "color"</code> and another has <code>$type: "gradient"</code>, these represent incompatible schemas that cannot be merged. The specification must outline what constitutes "mergeable" vs "unmergeable" token sets and provide clear rules for handling such conflicts.
-        </p>
-        <p class="issue">
-          The specification needs clear step-by-step instructions for how deep merging should occur, including detailed guidance on handling edge cases or when to error appropriately. This should include specific algorithms and decision trees for implementers to follow consistently.
-        </p>
-        <li><strong>Modifier Application</strong>: Apply the selected modifiers based on the inputs. Modifiers can override tokens from the base sets or introduce new tokens.</li>
-        <p class="issue">
-          The specification should clarify the resolution order when multiple modifiers are applied simultaneously. For instance, if both "theme" and "brand" modifiers are used and both attempt to override the same token, which modifier should take precedence? Clear precedence rules are needed to ensure consistent and predictable resolution behavior across implementations.
-        </p>
-        <li><strong>Aliasing and Namespacing</strong>: Apply any aliasing specified in the modifiers to namespace or rename tokens.</li>
-        <p class="issue">
-          The specification needs to clarify the different types of "aliasing" and their behavior during resolution. There are two distinct concepts being referred to as "aliasing": (1) <strong>Namespacing aliasing</strong> - where tokens are renamed/namespaced (e.g., "red.500" becomes "colors.red.500"), and (2) <strong>Token reference aliasing</strong> - where one token's value references another token's value. The specification should clearly distinguish between these concepts and address how namespacing aliases behave when tokens are overridden by later sets - specifically, if an alias points to a token that gets overridden, does the alias resolve to the new/overridden value?
-        </p>
-        <li><strong>Alias Resolution</strong>: Resolve any token references (aliases) using the combined tokens from the base sets and modifiers.</li>
-        <li><strong>Conflict Resolution</strong>: In case of conflicting tokens (same name and path), later modifiers or sets override earlier ones.</li>
-        <li><strong>Circular Reference Detection</strong>: Detect and handle circular references as errors.</li>
-        <li><strong>Final Output</strong>: Produce a flat, resolved set of tokens ready for consumption.</li>
-      </ol>
-
-      <section>
-        <h3>Detailed Steps</h3>
-        <section>
-          <h4>Input Validation</h4>
-          <ul>
-            <li>Verify that all provided modifier inputs correspond to defined modifiers.</li>
-            <li>Check that the input values are among the acceptable options defined in the modifiers.</li>
-          </ul>
-        </section>
-        <section>
-          <h4>Base Set Flattening</h4>
-          <ul>
-            <li>Load each token set in the order specified.</li>
-            <li>Merge the tokens, with later sets overriding earlier ones on name conflicts.</li>
-          </ul>
-        </section>
-        <section>
-          <h4>Modifier Application</h4>
-          <ul>
-            <li>For each modifier:
-              <ul>
-                <li>Apply any aliasing or namespacing specified in meta.</li>
-                <li>Load the token sets associated with the selected modifier value.</li>
-                <li>Merge these tokens with the base tokens, applying overrides as necessary.</li>
-              </ul>
-            </li>
-          </ul>
-        </section>
-        <section>
-          <h4>Alias Resolution</h4>
-          <p class="note">Alias resolution is performed on the fully merged set of tokens, after all base sets and modifiers have been applied. This allows for aliases to reference tokens from any loaded file.</p>
-          <ul>
-            <li>Iterate over all tokens to find references (e.g., {theme.accent}).</li>
-            <li>Resolve references first within the same token set.</li>
-            <li>If not found, resolve references from the modifiers, following the order of precedence.</li>
-            <li>Handle nested references recursively.</li>
-          </ul>
-        </section>
-        <section>
-          <h4>Conflict Resolution</h4>
-          <ul>
-            <li>In case of conflicting tokens:
-              <ul>
-                <li>Tokens from modifiers override tokens from base sets.</li>
-                <li>If multiple modifiers define the same token, the last applied modifier takes precedence.</li>
-              </ul>
-            </li>
-          </ul>
-        </section>
-        <section>
-          <h4>Circular Reference Detection</h4>
-          <ul>
-            <li>Detect any circular references during alias resolution.</li>
-            <li>If a circular reference is found, throw an error and halt the resolution process.</li>
-          </ul>
-        </section>
-      </section>
-    </section>
-
-    <section>
-      <h2>Resolver Resolution Example</h2>
-      <section>
-        <h3>Example Resolver json file</h3>
-        <div class="note">
-          <p>We need to decide if the resolver spec also follows the $name, $values, etc.</p>
-        </div>
-        <pre class="example json" title="Example Resolver">
-{
-  "name": "Example Resolver",
-  "sets": [
-    {
-      "name": "foundation",
-      "values": ["foundation.json"]
-    },
-    {
-      "values": ["components/button.json"]
-    }
-  ],
-  "modifiers": [
-    {
-      "name": "theme",
-      "type": "enumerated",
-      "values": [
-        {
-          "name": "light",
-          "values": ["themes/light.json"]
-        },
-        {
-          "name": "dark",
-          "values": ["themes/dark.json"]
-        }
-      ],
-      "meta": {
-        "default": "light",
-        "alias": "theme"
-      }
-    }
-  ]
-}
-        </pre>
-        <p class="issue">
-          The <code>alias</code> property should be renamed to <code>namespace</code> to make its purpose clearer. Additionally, it should be moved out of the generic <code>meta</code> property and included in the formal schema definition. Currently, any arbitrary value could exist associated with <code>alias</code> since it's within the unstructured <code>meta</code> object. Anything that is not 100% discardable should not live in <code>meta</code>.
-        </p>
-      </section>
-      <section>
-        <h3>Input</h3>
-        <pre class="example json" title="Input">
-{
-  "theme": "dark"
-}
-        </pre>
-      </section>
-      <section>
-        <h3>Token Files</h3>
-        <h4>foundation.json</h4>
-        <pre class="example json" title="foundation.json">
-{
-  "color": {
-    "brand": {
-      "primary": {
-        "$value": "#FF0000",
-        "$type": "color"
-      }
-    }
-  }
-}
-        </pre>
-        <h4>components/button.json</h4>
-        <pre class="example json" title="components/button.json">
-{
-  "button": {
-    "background": {
-      "$value": "{theme.accent}",
-      "$type": "color"
-    },
-    "padding": {
-      "$value": "8px",
-      "$type": "dimension"
-    }
-  }
-}
-        </pre>
-        <h4>themes/dark.json</h4>
-        <pre class="example json" title="themes/dark.json">
-{
-  "accent": {
-    "$value": "#00FF00",
-    "$type": "color"
-  }
-}
-        </pre>
-      </section>
-      <section>
-        <h3>Resolution Steps</h3>
-        <section>
-          <h4>Step 1: Input Validation</h4>
-          <ol>
-            <li>Confirm that "theme" is a defined modifier.</li>
-            <li>Verify that "dark" is a valid value for the "theme" modifier.</li>
-          </ol>
-        </section>
-        <section>
-          <h4>Step 2: Base Set Flattening</h4>
-          <ol start="3">
-            <li>Load foundation.json and components/button.json. File paths <em class="rfc2119">MUST</em> be resolved relative to the location of the resolver file.</li>
-          </ol>
-          <p>Merge (flatten) tokens, resulting in:</p>
-          <pre class="example json" title="Flattened Base Set">
-{
-  "color": {
-    "brand": {
-      "primary": {
-        "$value": "#FF0000",
-        "$type": "color"
-      }
-    }
-  },
-  "button": {
-    "background": {
-      "$value": "{theme.accent}",
-      "$type": "color"
-    },
-    "padding": {
-      "$value": "8px",
-      "$type": "dimension"
-    }
-  }
-}
-          </pre>
-        </section>
-        <section>
-          <h4>Step 3: Modifier Application</h4>
-          <ol start="4">
-            <li>Apply the "theme" modifier with value "dark".</li>
-            <li>Load themes/dark.json.</li>
-          </ol>
-          <p>Apply aliasing as per meta.alias ("theme"), resulting in:</p>
-          <pre class="example json" title="Aliased Modifier">
-{
-  "theme": {
-    "accent": {
-      "$value": "#00FF00",
-      "$type": "color"
-    }
-  }
-}
-          </pre>
-        </section>
-        <section>
-          <h4>Step 4: Alias Resolution</h4>
-          <p class="note">Alias resolution is performed on the fully merged set of tokens, after all base sets and modifiers have been applied. This allows for aliases to reference tokens from any loaded file.</p>
-          <ul>
-            <li>Resolve {theme.accent} in button.background.</li>
-            <li>Replace with #00FF00.</li>
-          </ul>
-        </section>
-        <section>
-          <h4>Step 5: Conflict Resolution</h4>
-          <ul>
-            <li>No conflicting tokens in this example.</li>
-          </ul>
-        </section>
-        <section>
-          <h4>Step 6: Final Output</h4>
-          <pre class="example json" title="Final Output">
-{
-  "color": {
-    "brand": {
-      "primary": {
-        "$value": "#FF0000",
-        "$type": "color"
-      }
-    }
-  },
-  "button": {
-    "background": {
-      "$value": "#00FF00",
-      "$type": "color"
-    },
-    "padding": {
-      "$value": "8px",
-      "$type": "dimension"
-    }
-  }
-}
-          </pre>
-        </section>
-      </section>
-    </section>
-
-    <section class="informative">
-      <h2>Use Cases</h2>
-      <section>
-        <h3>Style Dictionary Integration</h3>
-        <p>The Resolver Specification can be integrated with tools like <a href="https://amzn.github.io/style-dictionary/">Style Dictionary</a> to automate the generation of platform-specific design tokens.</p>
-        <p><strong>Example:</strong></p>
-        <ul>
-          <li>Use the resolver to generate the resolved token set based on the desired modifiers.</li>
-          <li>Feed the resolved token set into Style Dictionary.</li>
-          <li>Configure Style Dictionary to output tokens in the desired formats (e.g., CSS variables, Sass variables).</li>
-        </ul>
-      </section>
-      <section>
-        <h3>Real-World Scenario: Theming with Multiple Dimensions</h3>
-        <p>In large design systems, you might have multiple brands, each with light and dark themes, and accessibility modes (e.g., high contrast).</p>
-        <p><strong>Implementation:</strong></p>
-        <ul>
-          <li>Define modifiers for each dimension (e.g., "brand", "theme", "accessibility").</li>
-          <li>Use the resolver to combine base tokens with the appropriate modifiers.</li>
-          <li>Ensure that modifiers are orthogonal where possible to simplify the resolution logic.</li>
-        </ul>
-      </section>
-    </section>
-
-    <section class="informative">
-      <h2>Orthogonality</h2>
-      <p>Modifiers are considered <strong>orthogonal</strong> when they can be changed independently without affecting each other's resolution logic.</p>
-      <p><strong>Example of Orthogonal Modifiers:</strong></p>
-      <ul>
-        <li><strong>Theme</strong>: "light", "dark"</li>
-        <li><strong>Brand</strong>: "brandA", "brandB"</li>
-      </ul>
-      <p>You can mix any theme with any brand, resulting in all possible combinations.</p>
-      <p><strong>Example of Non-Orthogonal Modifiers:</strong></p>
-      <ul>
-        <li>A "theme" modifier that includes a "dimmed" option only available in "dark" mode.</li>
-      </ul>
-      <p>In such cases, the resolver must handle dependencies between modifiers, potentially by validating acceptable combinations or structuring modifiers to reflect the dependencies.</p>
-      <p class="issue">
-        This requires input from the resolver author to explicitly declare whether a modifier is purely orthogonal or not. This declaration should be upfront in the specification, otherwise lazy resolution cannot be supported without the resolver having to check the actual tokens in scope.
+        This document was produced by the Design Tokens W3C Community Group, and
+        contributions to this draft are governed by
+        <a href="https://www.w3.org/community/about/process/cla"
+          >Community Contributor License Agreement (CLA)</a
+        >, as specified by the
+        <a href="https://www.w3.org/community/about/process/#cgroups"
+          >W3C Community Group Process</a
+        >.
       </p>
     </section>
 
-    <section class="informative">
-      <h2>Future Extensions</h2>
-      <p>The Resolver Specification can be extended to handle more complex scenarios:</p>
-      <ul>
-        <li><strong>Conditional Modifiers</strong>: Modifiers that are applied based on conditions or contexts not specified directly in the input.</li>
-        <li><strong>Dynamic Resolution</strong>: Support for runtime evaluation of tokens based on environmental factors (e.g., screen size, user preferences).</li>
-        <li><strong>Dependency Graphs</strong>: Explicitly defining dependencies between modifiers to handle non-orthogonal scenarios.</li>
-      </ul>
-    </section>
+    <section
+      class="informative"
+      data-include="./introduction.md"
+      data-include-format="markdown"
+    ></section>
 
-    <section>
-      <h2>Conformance</h2>
-      <p>Tools implementing the Resolver Specification MUST:</p>
-      <ul>
-        <li><strong>Support the Resolution Process</strong>: Implement the resolution logic as defined, including input validation, base set flattening, modifier application, aliasing, and conflict resolution.</li>
-        <li><strong>Validate Inputs</strong>: Ensure that provided modifier inputs match the defined modifiers and acceptable values.</li>
-        <li><strong>Resolve Aliases Correctly</strong>: Handle token references accurately, including recursive references and detection of circular dependencies.</li>
-        <li><strong>Preserve Token Properties</strong>: Maintain additional token properties (e.g., description, type) throughout the resolution process.</li>
-        <li><strong>Handle Errors Gracefully</strong>: Provide meaningful error messages for issues like invalid inputs or circular references.</li>
-      </ul>
-    </section>
+    <section
+      class="informative"
+      data-include="./rationale.md"
+      data-include-format="markdown"
+    ></section>
 
-    <section class="appendix informative">
+    <section
+      class="informative"
+      data-include="./terminology.md"
+      data-include-format="markdown"
+    ></section>
+
+    <section
+      class="informative"
+      data-include="./file-format.md"
+      data-include-format="markdown"
+    ></section>
+
+    <section
+      class="informative"
+      data-include="./resolution-aliasing.md"
+      data-include-format="markdown"
+    ></section>
+
+    <section
+      class="informative"
+      data-include="./resolution-logic.md"
+      data-include-format="markdown"
+    ></section>
+
+    <section
+      data-include="./resolution-example.md"
+      data-include-format="markdown"
+    ></section>
+
+    <section
+      class="informative"
+      data-include="./use-cases.md"
+      data-include-format="markdown"
+    ></section>
+
+    <section
+      class="informative"
+      data-include="./orthogonality.md"
+      data-include-format="markdown"
+    ></section>
+
+    <section
+      class="informative"
+      data-include="./future-extensions.md"
+      data-include-format="markdown"
+    ></section>
+
+    <section
+      id="conformance"
+      data-include="./conformance.md"
+      data-include-format="markdown"
+    ></section>
+
+    <section id="acknowledgements" class="appendix informative">
       <h2>Acknowledgments</h2>
-      <p>We thank the members of the Design Tokens Community Group for their contributions and feedback, including:</p>
+      <p>
+        We thank the members of the Design Tokens Community Group for their
+        contributions and feedback, including:
+      </p>
       <ul>
         <li>[Contributors' Names]</li>
       </ul>
     </section>
 
-    <section class="appendix informative">
-      <h2>References</h2>
-      <dl>
-        <dt>Design Tokens Format Specification</dt>
-        <dd><a href="https://github.com/design-tokens/community-group">https://github.com/design-tokens/community-group</a></dd>
-        <dt>RFC 2119</dt>
-        <dd><a href="https://www.ietf.org/rfc/rfc2119.txt">https://www.ietf.org/rfc/rfc2119.txt</a></dd>
-        <dt>Style Dictionary</dt>
-        <dd><a href="https://amzn.github.io/style-dictionary/">https://amzn.github.io/style-dictionary/</a></dd>
-        <dt>Tokens Studio Plugin</dt>
-        <dd><a href="https://github.com/tokens-studio/figma-plugin">https://github.com/tokens-studio/figma-plugin</a></dd>
-      </dl>
-    </section>
+    <section
+      class="appendix informative"
+      data-include="./additional-context-and-information.md"
+      data-include-format="markdown"
+    ></section>
 
-    <section class="appendix informative">
-      <h2>Additional Context and Information</h2>
-      <p><em>This section is non-normative and intended for early reviewers.</em></p>
-      <section>
-        <h3>Resolution Aliasing</h3>
-        <p>Aliasing allows for dynamic namespacing or renaming of token paths during resolution. This is particularly useful when integrating external token sets or avoiding naming conflicts.</p>
-        <p><strong>Example:</strong></p>
-        <p>Given a token set size.json:</p>
-        <pre class="example json" title="size.json">
-{
-  "sm": {
-    "value": "1px",
-    "type": "dimension"
-  },
-  "lg": {
-    "value": "10px",
-    "type": "dimension"
-  }
-}
-        </pre>
-        <p>By applying an alias in the modifier's meta.alias, we can namespace these tokens:</p>
-        <pre class="example json" title="Aliased Modifier">
-{
-  "modifiers": [
-    {
-      "name": "size",
-      "type": "include",
-      "values": [
-        {
-          "name": "default",
-          "values": ["size.json"]
-        }
-      ],
-      "meta": {
-        "alias": "spacing"
-      }
-    }
-  ]
-}
-        </pre>
-        <p>Resulting in tokens accessible via spacing.sm and spacing.lg.</p>
-      </section>
-      
-      <section>
-        <h3>Real-World Use Case: GitHub Primer</h3>
-        <p>The GitHub Primer design system uses multiple dimensions, including themes and visual modes (e.g., colorblind modes). The Resolver Specification can represent these dimensions as modifiers, allowing for efficient resolution and management of tokens.</p>
-      </section>
-      <p class="note">
-        Question: Would it be worth to highlight some public design systems and how they would use the resolver spec for more relatable use cases?
-      </p>
-      <p class="issue">
-        While public design system examples could be valuable, generic use cases showing common dimensional patterns might be more important as foundational examples: single dimension (1 brand), two dimensions (1 brand + 2 themes), three dimensions (2 brands + 2 themes each), etc. These generic patterns would be the "meat and potatoes" compared to specific design system examples being the "cherry on the cake."
-      </p>
-      <section>
-        <h3>Orthogonality Considerations</h3>
-        <p>In scenarios where modifiers are not orthogonal, the resolver may need to enforce acceptable combinations and handle dependencies between modifiers. This can be achieved by:</p>
-        <ul>
-          <li>Defining valid combinations explicitly.</li>
-          <li>Using nested modifiers or modifier groups.</li>
-          <li>Providing validation logic to prevent invalid input combinations.</li>
-        </ul>
-      </section>
-    </section>
-    <section class="appendix informative">
-      <h2>Example 1: Brand Theming</h2>
-      
-      <p>Scenario: A company has multiple brands—Brand A and Brand B. Each brand has its own color palette and typography. Components like buttons and headers need to adapt based on the selected brand.</p>
-      <p class="issue">
-        These examples could be moved to the Resolver Spec netlify app for better presentation. If it uses Astro, interactive code tabs could be added to make the examples more engaging and easier to understand through hands-on exploration.
-      </p>
-      <section>
-        <h3>Resolver Definition</h3>
-        <pre class="example json" title="Brand Theming Resolver">
-{
-  "name": "Brand Theming Resolver",
-  "sets": [
-    {
-      "name": "base",
-      "values": ["tokens/base.json"]
-    },
-    {
-      "values": ["tokens/components.json"]
-    }
-  ],
-  "modifiers": [
-    {
-      "name": "brand",
-      "type": "enumerated",
-      "values": [
-        {
-          "name": "brandA",
-          "values": ["tokens/brands/brandA.json"]
-        },
-        {
-          "name": "brandB",
-          "values": ["tokens/brands/brandB.json"]
-        }
-      ],
-      "meta": {
-        "default": "brandA",
-        "alias": "brand"
-      }
-    }
-  ]
-}
-        </pre>
-      </section>
-      <section>
-        <h3>Token Files</h3>
-        <h4>tokens/base.json</h4>
-        <pre class="example json" title="tokens/base.json">
-{
-  "color": {
-    "text": {
-      "primary": {
-        "value": "#000000",
-        "type": "color"
-      }
-    }
-  },
-  "font": {
-    "family": {
-      "default": {
-        "value": "Arial, sans-serif",
-        "type": "font"
-      }
-    }
-  }
-}
-        </pre>
-        <h4>tokens/components.json</h4>
-        <pre class="example json" title="tokens/components.json">
-{
-  "button": {
-    "background": {
-      "value": "{brand.color.primary}",
-      "type": "color"
-    },
-    "fontFamily": {
-      "value": "{brand.font.family}",
-      "type": "font"
-    }
-  },
-  "header": {
-    "color": {
-      "value": "{brand.color.secondary}",
-      "type": "color"
-    }
-  }
-}
-        </pre>
-        <h4>tokens/brands/brandA.json</h4>
-        <pre class="example json" title="tokens/brands/brandA.json">
-{
-  "color": {
-    "primary": {
-      "value": "#FF5733",
-      "type": "color"
-    },
-    "secondary": {
-      "value": "#C70039",
-      "type": "color"
-    }
-  },
-  "font": {
-    "family": {
-      "value": "'Helvetica Neue', sans-serif",
-      "type": "font"
-    }
-  }
-}
-        </pre>
-        <h4>tokens/brands/brandB.json</h4>
-        <pre class="example json" title="tokens/brands/brandB.json">
-{
-  "color": {
-    "primary": {
-      "value": "#1F618D",
-      "type": "color"
-    },
-    "secondary": {
-      "value": "#2874A6",
-      "type": "color"
-    }
-  },
-  "font": {
-    "family": {
-      "value": "'Times New Roman', serif",
-      "type": "font"
-    }
-  }
-}
-        </pre>
-      </section>
-      <section>
-        <h3>Input</h3>
-        <pre class="example json" title="Input">
-{
-  "brand": "brandB"
-}
-        </pre>
-      </section>
-      <section>
-        <h3>Resolution Steps</h3>
-        <h4>Input Validation</h4>
-        <ul>
-          <li>Confirm that "brand" is a defined modifier.</li>
-          <li>Verify that "brandB" is a valid value for the "brand" modifier.</li>
-        </ul>
-        <h4>Base Set Flattening</h4>
-        <p>Load tokens/base.json and tokens/components.json.</p>
-        <p>Merge tokens:</p>
-        <pre class="example json" title="Merged Tokens">
-{
-  "color": {
-    "text": {
-      "primary": {
-        "value": "#000000",
-        "type": "color"
-      }
-    }
-  },
-  "font": {
-    "family": {
-      "default": {
-        "value": "Arial, sans-serif",
-        "type": "font"
-      }
-    }
-  },
-  "button": {
-    "background": {
-      "value": "{brand.color.primary}",
-      "type": "color"
-    },
-    "fontFamily": {
-      "value": "{brand.font.family}",
-      "type": "font"
-    }
-  },
-  "header": {
-    "color": {
-      "value": "{brand.color.secondary}",
-      "type": "color"
-    }
-  }
-}
-        </pre>
-        <h4>Modifier Application</h4>
-        <p>Apply the "brand" modifier with value "brandB".</p>
-        <p>Load tokens/brands/brandB.json.</p>
-        <p>Apply aliasing as per meta.alias ("brand"), resulting in:</p>
-        <pre class="example json" title="Aliased Modifier">
-{
-  "brand": {
-    "color": {
-      "primary": {
-        "value": "#1F618D",
-        "type": "color"
-      },
-      "secondary": {
-        "value": "#2874A6",
-        "type": "color"
-      }
-    },
-    "font": {
-      "family": {
-        "value": "'Times New Roman', serif",
-        "type": "font"
-      }
-    }
-  }
-}
-        </pre>
-        <h4>Alias Resolution</h4>
-        <ul>
-          <li>Resolve {brand.color.primary} in button.background:
-            <ul>
-              <li>Replace with #1F618D.</li>
-            </ul>
-          </li>
-          <li>Resolve {brand.font.family} in button.fontFamily:
-            <ul>
-              <li>Replace with 'Times New Roman', serif.</li>
-            </ul>
-          </li>
-          <li>Resolve {brand.color.secondary} in header.color:
-            <ul>
-              <li>Replace with #2874A6.</li>
-            </ul>
-          </li>
-        </ul>
-        <h4>Conflict Resolution</h4>
-        <p>No conflicts in this example.</p>
-        <h4>Final Output</h4>
-        <pre class="example json" title="Final Output">
-{
-  "color": {
-    "text": {
-      "primary": {
-        "value": "#000000",
-        "type": "color"
-      }
-    }
-  },
-  "font": {
-    "family": {
-      "default": {
-        "value": "Arial, sans-serif",
-        "type": "font"
-      }
-    }
-  },
-  "button": {
-    "background": {
-      "value": "#1F618D",
-      "type": "color"
-    },
-    "fontFamily": {
-      "value": "'Times New Roman', serif",
-      "type": "font"
-    }
-  },
-  "header": {
-    "color": {
-      "value": "#2874A6",
-      "type": "color"
-    }
-  }
-}
-        </pre>
-        <h4>Explanation:</h4>
-        <ul>
-          <li>By changing the "brand" modifier, we can switch between different brand themes without altering the base token definitions.</li>
-          <li>The resolver efficiently manages the brand-specific overrides and applies them to components.</li>
-        </ul>
-      </section>
-    </section>
+    <section
+      class="appendix informative"
+      data-include="./example1.md"
+      data-include-format="markdown"
+    ></section>
 
-    <section class="appendix informative">
-      <h2>Example 2: Component States</h2>
-      <p>Scenario: A design system includes buttons that change appearance based on their state—default, hover, active, and disabled. We want to manage these state-specific styles using modifiers.</p>
-      <section>
-        <h3>Resolver Definition</h3>
-        <pre class="example json" title="Component States Resolver">
-{
-  "name": "Component States Resolver",
-  "sets": [
-    {
-      "values": ["tokens/components/button.json"]
-    }
-  ],
-  "modifiers": [
-    {
-      "name": "state",
-      "type": "enumerated",
-      "values": [
-        {
-          "name": "default",
-          "values": ["tokens/states/default.json"]
-        },
-        {
-          "name": "hover",
-          "values": ["tokens/states/hover.json"]
-        },
-        {
-          "name": "active",
-          "values": ["tokens/states/active.json"]
-        },
-        {
-          "name": "disabled",
-          "values": ["tokens/states/disabled.json"]
-        }
-      ],
-      "meta": {
-        "default": "default"
-      }
-    }
-  ]
-}
-        </pre>
-      </section>
-      <section>
-        <h3>Token Files</h3>
-        <h4>tokens/components/button.json</h4>
-        <pre class="example json" title="tokens/components/button.json">
-{
-  "button": {
-    "background": {
-      "value": "{state.background}",
-      "type": "color"
-    },
-    "textColor": {
-      "value": "{state.textColor}",
-      "type": "color"
-    },
-    "borderColor": {
-      "value": "{state.borderColor}",
-      "type": "color"
-    }
-  }
-}
-        </pre>
-        <h4>tokens/states/default.json</h4>
-        <pre class="example json" title="tokens/states/default.json">
-{
-  "background": {
-    "value": "#FFFFFF",
-    "type": "color"
-  },
-  "textColor": {
-    "value": "#000000",
-    "type": "color"
-  },
-  "borderColor": {
-    "value": "#CCCCCC",
-    "type": "color"
-  }
-}
-        </pre>
-        <h4>tokens/states/hover.json</h4>
-        <pre class="example json" title="tokens/states/hover.json">
-{
-  "background": {
-    "value": "#F0F0F0",
-    "type": "color"
-  },
-  "textColor": {
-    "value": "#000000",
-    "type": "color"
-  },
-  "borderColor": {
-    "value": "#BBBBBB",
-    "type": "color"
-  }
-}
-        </pre>
-        <h4>tokens/states/active.json</h4>
-        <pre class="example json" title="tokens/states/active.json">
-{
-  "background": {
-    "value": "#E0E0E0",
-    "type": "color"
-  },
-  "textColor": {
-    "value": "#000000",
-    "type": "color"
-  },
-  "borderColor": {
-    "value": "#AAAAAA",
-    "type": "color"
-  }
-}
-        </pre>
-        <h4>tokens/states/disabled.json</h4>
-        <pre class="example json" title="tokens/states/disabled.json">
-{
-  "background": {
-    "value": "#F9F9F9",
-    "type": "color"
-  },
-  "textColor": {
-    "value": "#777777",
-    "type": "color"
-  },
-  "borderColor": {
-    "value": "#DDDDDD",
-    "type": "color"
-  }
-}
-        </pre>
-      </section>
-      <section>
-        <h3>Input</h3>
-        <pre class="example json" title="Input">
-{
-  "state": "hover"
-}
-        </pre>
-      </section>
-      <section>
-        <h3>Resolution Steps</h3>
-        <h4>Input Validation</h4>
-        <ul>
-          <li>Confirm that "state" is a defined modifier.</li>
-          <li>Verify that "hover" is a valid value for the "state" modifier.</li>
-        </ul>
-        <h4>Base Set Flattening</h4>
-        <p>Load tokens/components/button.json.</p>
-        <p>Tokens:</p>
-        <pre class="example json" title="Tokens">
-{
-  "button": {
-    "background": {
-      "value": "{state.background}",
-      "type": "color"
-    },
-    "textColor": {
-      "value": "{state.textColor}",
-      "type": "color"
-    },
-    "borderColor": {
-      "value": "{state.borderColor}",
-      "type": "color"
-    }
-  }
-}
-        </pre>
-        <h4>Modifier Application</h4>
-        <p>Apply the "state" modifier with value "hover".</p>
-        <p>Load tokens/states/hover.json.</p>
-        <p>Tokens under the "state" namespace:</p>
-        <pre class="example json" title="Tokens under 'state' namespace">
-{
-  "state": {
-    "background": {
-      "value": "#F0F0F0",
-      "type": "color"
-    },
-    "textColor": {
-      "value": "#000000",
-      "type": "color"
-    },
-    "borderColor": {
-      "value": "#BBBBBB",
-      "type": "color"
-    }
-  }
-}
-        </pre>
-        <h4>Alias Resolution</h4>
-        <ul>
-          <li>Resolve {state.background} in button.background:
-            <ul>
-              <li>Replace with #F0F0F0.</li>
-            </ul>
-          </li>
-          <li>Resolve {state.textColor} in button.textColor:
-            <ul>
-              <li>Replace with #000000.</li>
-            </ul>
-          </li>
-          <li>Resolve {state.borderColor} in button.borderColor:
-            <ul>
-              <li>Replace with #BBBBBB.</li>
-            </ul>
-          </li>
-        </ul>
-        <h4>Conflict Resolution</h4>
-        <p>No conflicts in this example.</p>
-        <h4>Final Output</h4>
-        <pre class="example json" title="Final Output">
-{
-  "button": {
-    "background": {
-      "value": "#F0F0F0",
-      "type": "color"
-    },
-    "textColor": {
-      "value": "#000000",
-      "type": "color"
-    },
-    "borderColor": {
-      "value": "#BBBBBB",
-      "type": "color"
-    }
-  }
-}
-        </pre>
-        <h4>Explanation:</h4>
-        <ul>
-          <li>By changing the "state" modifier, we can easily generate the tokens for different button states.</li>
-          <li>This approach keeps state-specific styles organized and separate from component definitions.</li>
-        </ul>
-      </section>
-    </section>
+    <section
+      class="appendix informative"
+      data-include="./example2.md"
+      data-include-format="markdown"
+    ></section>
 
-    <section class="appendix informative">
-      <h2>Example 3: Responsive Design</h2>
-      <p>Scenario: A design system needs to support responsive design by adjusting spacing and typography based on screen sizes—mobile, tablet, and desktop. We want to manage these variations using modifiers.</p>
-      <section>
-        <h3>Resolver Definition</h3>
-        <pre class="example json" title="Responsive Design Resolver">
-{
-  "name": "Responsive Design Resolver",
-  "sets": [
-    {
-      "name": "core",
-      "values": ["tokens/core.json"]
-    }
-  ],
-  "modifiers": [
-    {
-      "name": "screenSize",
-      "type": "enumerated",
-      "values": [
-        {
-          "name": "mobile",
-          "values": ["tokens/screens/mobile.json"]
-        },
-        {
-          "name": "tablet",
-          "values": ["tokens/screens/tablet.json"]
-        },
-        {
-          "name": "desktop",
-          "values": ["tokens/screens/desktop.json"]
-        }
-      ],
-      "meta": {
-        "default": "mobile",
-        "alias": "screen"
-      }
-    }
-  ]
-}
-        </pre>
-      </section>
-      <section>
-        <h3>Token Files</h3>
-        <h4>tokens/core.json</h4>
-        <pre class="example json" title="tokens/core.json">
-{
-  "spacing": {
-    "small": {
-      "value": "{screen.spacing.small}",
-      "type": "dimension"
-    },
-    "medium": {
-      "value": "{screen.spacing.medium}",
-      "type": "dimension"
-    },
-    "large": {
-      "value": "{screen.spacing.large}",
-      "type": "dimension"
-    }
-  },
-  "typography": {
-    "fontSize": {
-      "value": "{screen.typography.fontSize}",
-      "type": "dimension"
-    }
-  }
-}
-        </pre>
-        <h4>tokens/screens/mobile.json</h4>
-        <pre class="example json" title="tokens/screens/mobile.json">
-{
-  "spacing": {
-    "small": {
-      "value": "4px",
-      "type": "dimension"
-    },
-    "medium": {
-      "value": "8px",
-      "type": "dimension"
-    },
-    "large": {
-      "value": "12px",
-      "type": "dimension"
-    }
-  },
-  "typography": {
-    "fontSize": {
-      "value": "14px",
-      "type": "dimension"
-    }
-  }
-}
-        </pre>
-        <h4>tokens/screens/tablet.json</h4>
-        <pre class="example json" title="tokens/screens/tablet.json">
-{
-  "spacing": {
-    "small": {
-      "value": "6px",
-      "type": "dimension"
-    },
-    "medium": {
-      "value": "12px",
-      "type": "dimension"
-    },
-    "large": {
-      "value": "18px",
-      "type": "dimension"
-    }
-  },
-  "typography": {
-    "fontSize": {
-      "value": "16px",
-      "type": "dimension"
-    }
-  }
-}
-        </pre>
-        <h4>tokens/screens/desktop.json</h4>
-        <pre class="example json" title="tokens/screens/desktop.json">
-{
-  "spacing": {
-    "small": {
-      "value": "8px",
-      "type": "dimension"
-    },
-    "medium": {
-      "value": "16px",
-      "type": "dimension"
-    },
-    "large": {
-      "value": "24px",
-      "type": "dimension"
-    }
-  },
-  "typography": {
-    "fontSize": {
-      "value": "18px",
-      "type": "dimension"
-    }
-  }
-}
-        </pre>
-      </section>
-      <section>
-        <h3>Input</h3>
-        <pre class="example json" title="Input">
-{
-  "screenSize": "desktop"
-}
-        </pre>
-      </section>
-      <section>
-        <h3>Resolution Steps</h3>
-        <h4>Input Validation</h4>
-        <ul>
-          <li>Confirm that "screenSize" is a defined modifier.</li>
-          <li>Verify that "desktop" is a valid value for the "screenSize" modifier.</li>
-        </ul>
-        <h4>Base Set Flattening</h4>
-        <p>Load tokens/core.json.</p>
-        <p>Tokens:</p>
-        <pre class="example json" title="Tokens">
-{
-  "spacing": {
-    "small": {
-      "value": "{screen.spacing.small}",
-      "type": "dimension"
-    },
-    "medium": {
-      "value": "{screen.spacing.medium}",
-      "type": "dimension"
-    },
-    "large": {
-      "value": "{screen.spacing.large}",
-      "type": "dimension"
-    }
-  },
-  "typography": {
-    "fontSize": {
-      "value": "{screen.typography.fontSize}",
-      "type": "dimension"
-    }
-  }
-}
-        </pre>
-        <h4>Modifier Application</h4>
-        <p>Apply the "screenSize" modifier with value "desktop".</p>
-        <p>Load tokens/screens/desktop.json.</p>
-        <p>Apply aliasing as per meta.alias ("screen"), resulting in:</p>
-        <pre class="example json" title="Aliased Modifier">
-{
-  "screen": {
-    "spacing": {
-      "small": {
-        "value": "8px",
-        "type": "dimension"
-      },
-      "medium": {
-        "value": "16px",
-        "type": "dimension"
-      },
-      "large": {
-        "value": "24px",
-        "type": "dimension"
-      }
-    },
-    "typography": {
-      "fontSize": {
-        "value": "18px",
-        "type": "dimension"
-      }
-    }
-  }
-}
-        </pre>
-        <h4>Alias Resolution</h4>
-        <ul>
-          <li>Resolve {screen.spacing.small} in spacing.small:
-            <ul>
-              <li>Replace with 8px.</li>
-            </ul>
-          </li>
-          <li>Resolve {screen.spacing.medium} in spacing.medium:
-            <ul>
-              <li>Replace with 16px.</li>
-            </ul>
-          </li>
-          <li>Resolve {screen.spacing.large} in spacing.large:
-            <ul>
-              <li>Replace with 24px.</li>
-            </ul>
-          </li>
-          <li>Resolve {screen.typography.fontSize} in typography.fontSize:
-            <ul>
-              <li>Replace with 18px.</li>
-            </ul>
-          </li>
-        </ul>
-        <h4>Conflict Resolution</h4>
-        <p>No conflicts in this example.</p>
-        <h4>Final Output</h4>
-        <pre class="example json" title="Final Output">
-{
-  "spacing": {
-    "small": {
-      "value": "8px",
-      "type": "dimension"
-    },
-    "medium": {
-      "value": "16px",
-      "type": "dimension"
-    },
-    "large": {
-      "value": "24px",
-      "type": "dimension"
-    }
-  },
-  "typography": {
-    "fontSize": {
-      "value": "18px",
-      "type": "dimension"
-    }
-  }
-}
-        </pre>
-        <h4>Explanation:</h4>
-        <ul>
-          <li>By changing the "screenSize" modifier, we can generate tokens appropriate for different devices.</li>
-          <li>This method centralizes responsive adjustments, making it easier to maintain and update.</li>
-        </ul>
-      </section>
-    </section>
-
+    <section
+      class="appendix informative"
+      data-include="./example3.md"
+      data-include-format="markdown"
+    ></section>
   </body>
-</html> 
+</html>

--- a/technical-reports/resolver/introduction.md
+++ b/technical-reports/resolver/introduction.md
@@ -1,0 +1,10 @@
+# Introduction
+
+Design tokens are key-value pairs that represent design decisions, allowing for consistent use across different platforms and tools. In complex design systems, there is a need to manage multiple dimensions such as themes, modes (e.g., light and dark), brands, and variants. This introduces challenges in organizing tokens, resolving references, and applying overrides.
+
+The Resolver Specification addresses these challenges by introducing a structured mechanism to:
+
+- Organize tokens into **sets** and **modifiers**.
+- Define how tokens are **resolved** when multiple sets and modifiers are involved.
+- Support **scalability** by handling arbitrary dimensions without complicating the core token definitions.
+- Maintain **modularity** and **reusability** by allowing tokens to be combined and overridden in a controlled manner.

--- a/technical-reports/resolver/orthogonality.md
+++ b/technical-reports/resolver/orthogonality.md
@@ -1,0 +1,26 @@
+# Orthogonality
+
+Modifiers are considered **orthogonal** when they can be changed independently without affecting each other's resolution logic.
+
+<aside class="example" title="Orthogonal modifiers">
+
+- **Theme**: "light", "dark"
+- **Brand**: "brandA", "brandB"
+
+You can mix any theme with any brand, resulting in all possible combinations.
+
+</aside>
+
+<aside class="example" title="Non-orthogonal modifiers">
+
+- A "theme" modifier that includes a "dimmed" option only available in "dark" mode.
+
+In such cases, the resolver must handle dependencies between modifiers, potentially by validating acceptable combinations or structuring modifiers to reflect the dependencies.
+
+<aside class="issue">
+
+This requires input from the resolver author to explicitly declare whether a modifier is purely orthogonal or not. This declaration should be upfront in the specification, otherwise lazy resolution cannot be supported without the resolver having to check the actual tokens in scope.
+
+</aside>
+
+</aside>

--- a/technical-reports/resolver/rationale.md
+++ b/technical-reports/resolver/rationale.md
@@ -1,0 +1,48 @@
+## Rationale
+
+### Context and Problem Statement
+
+In design systems, especially those at scale, managing multiple themes, modes, brands, and other modifiers can become complex. Designers and developers often struggle with:
+
+- **Naming Conflicts**: Using complex naming conventions to differentiate tokens across different themes or modes, leading to brittle and hard-to-maintain token names.
+- **Scalability Issues**: Difficulty in scaling token management when new dimensions are added, such as additional themes or brands.
+- **Tooling Limitations**: Existing tools may not support multi-dimensional token resolution, forcing teams to create workarounds that complicate their workflows.
+- **Separation of Concerns**: Embedding resolution logic within token files mixes data with behavior, violating separation of
+  concerns.
+
+### Parameters
+
+- **Simplicity**: The solution should keep token files simple and editable by hand, without requiring complex tooling.
+- **Scalability**: It should support arbitrary dimensions (e.g., themes, modes, brands) without significant overhead.
+- **Modularity**: Tokens should be organized in a way that allows for modularity and reusability.
+- **Separation of Concerns**: Resolution logic should be externalized from token definitions.
+
+### Background
+
+Existing approaches, such as embedding modifiers directly into token names or using global theme files, have limitations. They often lead to:
+
+- **Global Namespace Pollution**: All tokens exist in a single global namespace, increasing the likelihood of naming conflicts.
+- **High Cognitive Load**: Designers and developers must remember complex naming conventions and how different tokens relate across dimensions.
+- **Performance Issues**: Resolving tokens in systems with many dimensions can be slow due to the combinatorial explosion of permutations.
+
+### Motivation
+
+The Resolver Specification aims to:
+
+- **Simplify Token Management**: By externalizing resolution logic, token files remain simple and focused on defining values.
+- **Enhance Modularity**: Tokens can be organized into sets and modifiers, allowing teams to work on isolated components or themes without affecting others.
+- **Improve Performance**: By reducing the scope of tokens in resolution, the process becomes faster and more efficient.
+
+  <aside class="issue">
+
+  The term "process" needs clarification - what specific process is being referred to? Is this the "resolution process of the resolver"? More explanation is needed to understand exactly what becomes faster and more efficient when token scope is reduced during resolution.
+
+  </aside>
+
+- **Facilitate Tool Integration**: Providing a standard way to define resolution logic makes it easier for tools to integrate and automate token management.
+
+  <aside class="issue">
+
+  A side effect of using a resolver should be the ability to have a clear dependency graph of how a resolution request would occur purely based on the inputs. This would enable better understanding of modifier interactions and support more efficient resolution strategies.
+
+  </aside>

--- a/technical-reports/resolver/resolution-aliasing.md
+++ b/technical-reports/resolver/resolution-aliasing.md
@@ -1,0 +1,155 @@
+# Resolution Aliasing
+
+Aliasing allows for dynamic namespacing or renaming of token paths during resolution. This is particularly useful when integrating external token sets or avoiding naming conflicts.
+
+<aside class="issue">
+
+**Namespace vs Alias Terminology:** Should the `alias` property be renamed to `namespace` to avoid confusion with token aliases (references to other tokens)?
+
+**Redundancy with Modifier Names:** The `meta.alias` property may be redundant since modifiers already have a `name` property that could serve the same namespacing purpose.
+
+**Auto-namespacing Concerns:** The automatic application of namespacing for modifiers introduces significant complexity and potential issues:
+
+- Requires pre-resolution conflict checking across all sets and modifiers
+- Modifier JSON must be complete sets to avoid undefined token references
+- Risk of infinite loops if modifiers reference tokens in other modifier namespaces
+- Backwards compatibility issues requiring extensive token renames in existing design systems
+
+**Alternative Approach:** Consider removing auto-namespacing for modifiers and using shared merging logic between sets and modifiers for better compatibility and simplicity.
+
+</aside>
+
+**Example:**
+
+<aside class="example">
+
+Given a token set size.json:</p>
+
+```json
+{
+  "sm": {
+    "value": "1px",
+    "type": "dimension"
+  },
+  "lg": {
+    "value": "10px",
+    "type": "dimension"
+  }
+}
+```
+
+By applying an alias in the modifier's meta.alias, we can namespace these tokens:
+
+```json
+{
+  "modifiers": [
+    {
+      "name": "size",
+      "type": "include",
+      "values": [
+        {
+          "name": "default",
+          "values": ["size.json"]
+        }
+      ],
+      "meta": {
+        "alias": "spacing"
+      }
+    }
+  ]
+}
+```
+
+Resulting in tokens accessible via spacing.sm and spacing.lg.
+
+<aside class="issue">
+
+If the `meta.alias` behavior described above is normative/required behavior, it should not be part of the generic `meta` property but should be defined as part of the formal schema. Alternatively, if this is just an example of tooling-specific behavior, it should be clearly called out as such and not presented as part of the core specification.
+
+</aside>
+
+</aside>
+
+<aside class="example">
+
+Source: <a href="https://resolver-spec.netlify.app/reference/schema/">https://resolver-spec.netlify.app/reference/schema/</a>
+
+```json
+{
+  "$id": "https://schemas.tokens.studio/prototype/resolver.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "Resolver Specification",
+  "$defs": {
+    "tokenSet": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "values": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "required": ["values"]
+    },
+    "modifier": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "values": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "values": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            },
+            "required": ["name", "values"]
+          }
+        },
+        "meta": {
+          "type": "object",
+          "additionalProperties": true
+        }
+      },
+      "required": ["name", "values"]
+    }
+  },
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
+    "sets": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/tokenSet"
+      }
+    },
+    "modifiers": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/modifier"
+      }
+    }
+  },
+  "required": ["sets", "modifiers"]
+}
+```
+
+</aside>

--- a/technical-reports/resolver/resolution-example.md
+++ b/technical-reports/resolver/resolution-example.md
@@ -1,0 +1,199 @@
+# Resolver Resolution Example
+
+<aside class="example">
+
+<aside class="ednote">
+
+We need to decide if the resolver spec also follows the $name, $values, etc.</aside>
+
+```json
+{
+  "name": "Example Resolver",
+  "sets": [
+    {
+      "name": "foundation",
+      "values": ["foundation.json"]
+    },
+    {
+      "values": ["components/button.json"]
+    }
+  ],
+  "modifiers": [
+    {
+      "name": "theme",
+      "type": "enumerated",
+      "values": [
+        {
+          "name": "light",
+          "values": ["themes/light.json"]
+        },
+        {
+          "name": "dark",
+          "values": ["themes/dark.json"]
+        }
+      ],
+      "meta": {
+        "default": "light",
+        "alias": "theme"
+      }
+    }
+  ]
+}
+```
+
+<aside class="issue">
+
+The `alias` property should be renamed to `namespace` to make its purpose clearer. Additionally, it should be moved out of the generic `meta` property and included in the formal schema definition. Currently, any arbitrary value could exist associated with `alias` since it's within the unstructured `meta` object. Anything that is not 100% discardable should not live in `meta`.
+
+</aside>
+
+#### Input
+
+```json
+{
+  "theme": "dark"
+}
+```
+
+#### Token file: foundation.json
+
+```json
+{
+  "color": {
+    "brand": {
+      "primary": {
+        "$value": "#FF0000",
+        "$type": "color"
+      }
+    }
+  }
+}
+```
+
+#### Token file: components/button.json
+
+```json
+{
+  "button": {
+    "background": {
+      "$value": "{theme.accent}",
+      "$type": "color"
+    },
+    "padding": {
+      "$value": "8px",
+      "$type": "dimension"
+    }
+  }
+}
+```
+
+#### Token file: themes/dark.json
+
+```json
+{
+  "accent": {
+    "$value": "#00FF00",
+    "$type": "color"
+  }
+}
+```
+
+#### Resolution Step 1: Input Validation
+
+1. Confirm that "theme" is a defined modifier.
+2. Verify that "dark" is a valid value for the "theme" modifier.
+
+#### Resolution Step 2: Base Set Flattening
+
+<ol start="3">
+
+<li>
+
+Load foundation.json and components/button.json. File paths MUST be resolved relative to the location of the resolver file.
+
+</li>
+
+</ol>
+
+Merge (flatten) tokens, resulting in:
+
+```json
+{
+  "color": {
+    "brand": {
+      "primary": {
+        "$value": "#FF0000",
+        "$type": "color"
+      }
+    }
+  },
+  "button": {
+    "background": {
+      "$value": "{theme.accent}",
+      "$type": "color"
+    },
+    "padding": {
+      "$value": "8px",
+      "$type": "dimension"
+    }
+  }
+}
+```
+
+#### Resolution Step 3: Modifier Application
+
+<ol start="4">
+  <li>Apply the "theme" modifier with value "dark".</li>
+  <li>Load themes/dark.json.</li>
+</ol>
+
+Apply aliasing as per meta.alias ("theme"), resulting in:
+
+```json
+{
+  "theme": {
+    "accent": {
+      "$value": "#00FF00",
+      "$type": "color"
+    }
+  }
+}
+```
+
+#### Resolution Step 4: Alias Resolution
+
+<p class="note">Alias resolution is performed on the fully merged set of tokens, after all base sets and modifiers have been applied. This allows for aliases to reference tokens from any loaded file. </p>
+
+- Resolve {theme.accent} in button.background.
+- Replace with #00FF00.
+
+#### Resolution Step 5: Conflict Resolution</h4>
+
+- No conflicting tokens in this example.
+
+#### Resolution Step 6: Final Output
+
+```json
+{
+  "color": {
+    "brand": {
+      "primary": {
+        "$value": "#FF0000",
+        "$type": "color"
+      }
+    }
+  },
+  "button": {
+    "background": {
+      "$value": "#00FF00",
+      "$type": "color"
+    },
+    "padding": {
+      "$value": "8px",
+      "$type": "dimension"
+    }
+  }
+}
+```
+
+</aside>

--- a/technical-reports/resolver/resolution-logic.md
+++ b/technical-reports/resolver/resolution-logic.md
@@ -1,0 +1,94 @@
+# Resolution Logic
+
+The resolution process involves the following steps:
+
+1. **Input Validation**: Ensure the provided inputs match the expected modifiers and their acceptable values.
+
+   <aside class="issue">
+
+   The term "inputs" is used throughout the specification but never formally defined. Inputs appear to represent the permutation or combination of modifiers being selected for resolution - essentially the question "What would my output look like given some combination of modifiers being enabled or chosen?" This fundamental concept should be clearly defined, potentially as "data" or with a more specific term that clarifies its role in the resolution process.
+
+   </aside>
+
+2. **Base Set Flattening**: Load and merge the token sets specified in the **sets** array. Later sets override earlier ones if there are naming conflicts.
+
+   <aside class="issue">
+
+   The merging process needs detailed specification to handle DTCG token data correctly. Simply performing a deep merge on raw JSON could yield different results than fully interpreting the DTCG data first and then merging. This is particularly important for inheritable format properties like `$type`. For example, when loading two JSON files with a top-level "color" key where one has `$type: "color"` and another has `$type: "gradient"`, these represent incompatible schemas that cannot be merged. The specification must outline what constitutes "mergeable" vs "unmergeable" token sets and provide clear rules for handling such conflicts.
+
+   </aside>
+
+   <aside class="issue">
+
+   The specification needs clear step-by-step instructions for how deep merging should occur, including detailed guidance on handling edge cases or when to error appropriately. This should include specific algorithms and decision trees for implementers to follow consistently.
+
+   </aside>
+
+3. **Modifier Application**: Apply the selected modifiers based on the inputs. Modifiers can override tokens from the base sets or introduce new tokens.
+
+   <aside class="issue">
+
+   The specification should clarify the resolution order when multiple modifiers are applied simultaneously. For instance, if both "theme" and "brand" modifiers are used and both attempt to override the same token, which modifier should take precedence? Clear precedence rules are needed to ensure consistent and predictable resolution behavior across implementations.
+
+   </aside>
+
+4. **Aliasing and Namespacing**: Apply any aliasing specified in the modifiers to namespace or rename tokens.
+
+   <aside class="issue">
+
+   The specification needs to clarify the different types of "aliasing" and their behavior during resolution. There are two distinct concepts being referred to as "aliasing": (1) **Namespacing aliasing** - where tokens are renamed/namespaced (e.g., "red.500" becomes "colors.red.500"), and (2) **Token reference aliasing** - where one token's value references another token's value. The specification should clearly distinguish between these concepts and address how namespacing aliases behave when tokens are overridden by later sets - specifically, if an alias points to a token that gets overridden, does the alias resolve to the new/overridden value?
+
+   </aside>
+
+5. **Alias Resolution**: Resolve any token references (aliases) using the combined tokens from the base sets and modifiers.
+
+6. **Conflict Resolution**: In case of conflicting tokens (same name and path), later modifiers or sets override earlier ones.
+
+7. **Circular Reference Detection**: Detect and handle circular references as errors.
+
+8. **Final Output**: Produce a flat, resolved set of tokens ready for consumption.
+
+### Detailed Steps
+
+#### Input Validation
+
+- Verify that all provided modifier inputs correspond to defined
+  modifiers.
+- Check that the input values are among the acceptable options
+  defined in the modifiers.
+
+#### Base Set Flattening
+
+- Load each token set in the order specified.
+- Merge the tokens, with later sets overriding earlier ones on name conflicts.
+
+#### Modifier Application
+
+- For each modifier:
+  - Apply any aliasing or namespacing specified in meta.
+  - Load the token sets associated with the selected modifier value.
+  - Merge these tokens with the base tokens, applying overrides as necessary.
+
+#### Alias Resolution
+
+<aside class="note">
+
+Alias resolution is performed on the fully merged set of tokens, after all base sets and modifiers have been applied. This allows for aliases to reference tokens from any loaded file.
+
+</aside>
+
+- Iterate over all tokens to find references (e.g., {theme.accent}).
+- Resolve references first within the same token set.
+- If not found, resolve references from the modifiers, following the order of precedence.
+- Handle nested references recursively.
+
+#### Conflict Resolution
+
+- In case of conflicting tokens:
+  - Tokens from modifiers override tokens from base sets.
+  - If multiple modifiers define the same token, the last applied modifier takes precedence.
+
+#### Circular Reference Detection
+
+- Detect any circular references during alias resolution.
+- If a circular reference is found, throw an error and halt the resolution process.

--- a/technical-reports/resolver/terminology.md
+++ b/technical-reports/resolver/terminology.md
@@ -1,0 +1,103 @@
+# Resolver Terminology
+
+<dl>
+<dt>Resolver</dt>
+<dd>
+
+A mechanism that combines token sets and applies modifiers to produce a final, resolved set of design tokens.
+
+</dd>
+<dt>Token Set</dt>
+<dd>
+
+A collection of design tokens grouped together, often representing foundational tokens, component-specific tokens, or theme-specific tokens.
+
+</dd>
+<dt>Dimension</dt>
+<dd>
+
+Dimensions are categories used to organize your design tokens. See them as contexts in which token values might change:
+
+- Brands
+- Surface
+- Language direction
+- Themes
+- Platform
+- Screen size
+- Density
+- Component
+- State
+- Variant
+- Contrast
+
+<aside class="issue">
+
+The term "Dimension" is potentially confusing since "Dimension" is also a type of token and a general concept. Consider using "Context" instead, which aligns with the existing definition as "contexts in which token values might change." Additionally, explicit mention of color schemes may be problematic - developers often distinguish between "themes" and "color modes" (like Windows High Contrast mode for accessibility), and it's unclear whether everyone would understand themes to encompass dark/light/high-contrast modes.
+
+</aside>
+
+</dd>
+
+<dt>Modifier</dt>
+
+<dd>
+
+An entity that modifies or overrides tokens in the base sets. Modifiers can represent dimensions like themes, modes, brands, or any other contextual variations.
+
+<dl>
+
+<dt>Enumerated Modifier</dt>
+<dd>
+
+A modifier with predefined, named values (e.g., "light", "dark" for a theme modifier).
+
+</dd>
+<dt>Include Modifier</dt>
+<dd>
+
+A modifier that replaces or includes entire token sets during resolution.
+
+</dd>
+<dt>Alias</dt>
+<dd>
+
+An optional property that allows for namespacing or renaming token paths during resolution.
+
+<aside class="issue">
+
+The modifier types and their behaviors aren't clear from these definitions alone. Real-world examples showing how Enumerated Modifiers, Include Modifiers, and Alias properties work in practice would help clarify their purpose and usage.
+
+</aside>
+
+</dd>
+
+</dl>
+
+</dd>
+
+<dt>Input</dt>
+<dd>
+
+Parameters provided to the resolver to specify which modifiers to apply during the resolution process.
+
+</dd>
+<dt>Resolution</dt>
+<dd>
+
+The process of combining token sets and applying modifiers based on the specified inputs to produce the final set of tokens.
+
+<aside class="issue">
+
+The specification should address different real-world resolution use cases and their performance implications: **full upfront resolution** (resolving all possible combinations ahead of time), **lazy resolution** (resolving on-demand), and **partial resolution** for complex components. Without being upfront about token combinations and scopes, systems face combinatorial explosion problems that make resolution inefficient. There may be significant performance aspects to consider, especially for JIT (Just-In-Time) resolution scenarios. Input from tool makers like Figma and other design platforms would be valuable to understand real-world performance requirements and constraints.
+
+</aside>
+
+</dd>
+
+<dt>Orthogonality</dt>
+<dd>
+
+The property of modifiers being independent of each other, allowing them to be combined freely without affecting each other's resolution logic.
+
+</dd>
+</dl>

--- a/technical-reports/resolver/use-cases.md
+++ b/technical-reports/resolver/use-cases.md
@@ -1,0 +1,25 @@
+# Use Cases
+
+### Style Dictionary Integration
+
+The Resolver Specification can be integrated with tools like [Style Dictionary](https://amzn.github.io/style-dictionary/) to automate the generation of platform-specific design tokens.
+
+<aside class="example" title="Style Dictionary uses">
+
+- Use the resolver to generate the resolved token set based on the desired modifiers.
+- Feed the resolved token set into Style Dictionary.
+- Configure Style Dictionary to output tokens in the desired formats (e.g., CSS variables, Sass variables).
+
+</aside>
+
+<aside class="example" title="Theming with multiple dimensions">
+
+In large design systems, you might have multiple brands, each with light and dark themes, and accessibility modes (e.g., high contrast).
+
+**Implementation:**
+
+- Define modifiers for each dimension (e.g., "brand", "theme", "accessibility").
+- Use the resolver to combine base tokens with the appropriate modifiers.
+- Ensure that modifiers are orthogonal where possible to simplify the resolution logic.
+
+</aside>


### PR DESCRIPTION
## Changes

Without changing any content, organizes specification into individual markdown files to match the existing setup of this project.

### Minor adjustments

Also without adjusting any language or organization, some cleanup was made to better organize the sections which seemed unintentional. Examples:

**Before**

_Not only were example descriptions outside of the “Example” container, there were other instances of a single example being split between multiple examples, which seemed accidental:_

<img width="1704" height="1062" alt="before" src="https://github.com/user-attachments/assets/c4136a2c-8cee-4331-b822-710c70dd3f8b" />

<img width="1770" height="1478" alt="before-2" src="https://github.com/user-attachments/assets/8529c6b7-71dc-4185-845d-b2bb78e70794" />


**After**

_Examples are self-contained and follow a logical structure._

<img width="1756" height="1176" alt="after" src="https://github.com/user-attachments/assets/327eacd4-1934-438c-a07b-2042127acefa" />

<img width="1969" height="1475" alt="after-2" src="https://github.com/user-attachments/assets/7ab709a7-8cbb-45fb-a24c-65623afebae4" />

---

A minor cleanup to “references” was made, since ReSpec auto-generates this section correctly. Future additions will 



## How to Review

The proof this was only an organizational change is in the outline:

**Before**

<img width="400" alt="before-outline" src="https://github.com/user-attachments/assets/2629fe3a-33c5-4be1-aa58-ba7800ddd248" />


**After**

<img width="400" alt="after-outline" src="https://github.com/user-attachments/assets/de959e28-cef1-4b3d-aaee-63f322fe7d35" />

The last item: **Example 3**, only changed from “F” to “E” because of the change to “References” mentioned above—our updated version of ReSpec autogenerates this section, at the end.

Not shown in this screenshot, but all other sections match 1:1 with the original outline. The only difference being some headlines were consolidated into examples, which was the mistake mentioned above.


This PR is just for historic purposes
