### PR TITLE
chore(www): Fix dev server refresh when editing respec

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,13 +40,16 @@ pnpm run build
 
 ### Commands
 
-The following commands can be run from the project root:
+The following commands can be run from the **project root**:
 
 | Command          | Description                                       |
 | :--------------- | :------------------------------------------------ |
 | `pnpm run dev`   | Run designtokens.org locally in development mode. |
 | `pnpm run lint`  | Lint the project.                                 |
 | `pnpm run build` | Make a static build of the website.               |
+
+> [!NOTE]
+> You’ll also find `pnpm run dev` commands both in `www` and `technical-reports` folders. Those should only be used for debugging purposes, as they only run part of the workflow.
 
 ### Project structure
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,8 +33,8 @@ importers:
         specifier: ^3.0.0
         version: 3.0.0
       respec:
-        specifier: ^35.4.1
-        version: 35.4.1
+        specifier: ^35.5.0
+        version: 35.5.0
 
   www:
     devDependencies:
@@ -205,6 +205,11 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  '@puppeteer/browsers@2.10.6':
+    resolution: {integrity: sha512-pHUn6ZRt39bP3698HFQlu2ZHCkS/lPcpv7fVQcGBSzNNygw171UXAKrCUhy+TEMw4lEttOKDgNpb04hwUAJeiQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   '@sindresorhus/slugify@2.2.1':
     resolution: {integrity: sha512-MkngSCRZ8JdSOCHRaYd+D01XhvU3Hjy6MGl06zhOk614hp9EOAp5gIkBeQg7wtmxpitU6eAL4kdiRMcJa2dlrw==}
     engines: {node: '>=12'}
@@ -363,8 +368,20 @@ packages:
   bare-events@2.5.4:
     resolution: {integrity: sha512-+gFfDkR8pj4/TrWCGUGWmJIkBwuxPS5F+a5yWjOHQt2hHvNZd5YLzadjmDUtFmMM4y429bnKLa8bYBMHcYdnQA==}
 
+  bare-events@2.6.1:
+    resolution: {integrity: sha512-AuTJkq9XmE6Vk0FJVNq5QxETrSA/vKHarWVBG5l/JbdCL1prJemiyJqUS0jrlXO0MftuPq4m3YVYhoNc5+aE/g==}
+
   bare-fs@4.1.5:
     resolution: {integrity: sha512-1zccWBMypln0jEE05LzZt+V/8y8AQsQQqxtklqaIyg5nu6OAYFhZxPXinJTSG+kU5qyNmeLgcn9AW7eHiCHVLA==}
+    engines: {bare: '>=1.16.0'}
+    peerDependencies:
+      bare-buffer: '*'
+    peerDependenciesMeta:
+      bare-buffer:
+        optional: true
+
+  bare-fs@4.2.0:
+    resolution: {integrity: sha512-oRfrw7gwwBVAWx9S5zPMo2iiOjxyiZE12DmblmMQREgcogbNO0AFaZ+QBxxkEXiPspcpvO/Qtqn8LabUx4uYXg==}
     engines: {bare: '>=1.16.0'}
     peerDependencies:
       bare-buffer: '*'
@@ -381,6 +398,17 @@ packages:
 
   bare-stream@2.6.5:
     resolution: {integrity: sha512-jSmxKJNJmHySi6hC42zlZnq00rga4jjxcgNZjY9N5WlOe/iOoGRtdwGsHzQv2RlH2KOYMwGUXhf2zXd32BA9RA==}
+    peerDependencies:
+      bare-buffer: '*'
+      bare-events: '*'
+    peerDependenciesMeta:
+      bare-buffer:
+        optional: true
+      bare-events:
+        optional: true
+
+  bare-stream@2.7.0:
+    resolution: {integrity: sha512-oyXQNicV1y8nc2aKffH+BUHFRXmx6VrPzlnaEvMhram0nPBrKcEdcyBg5r08D0i8VxngHFAiVyn1QKXpSG0B8A==}
     peerDependencies:
       bare-buffer: '*'
       bare-events: '*'
@@ -479,6 +507,11 @@ packages:
 
   chromium-bidi@5.1.0:
     resolution: {integrity: sha512-9MSRhWRVoRPDG0TgzkHrshFSJJNZzfY5UFqUMuksg7zL1yoZIZ3jLB0YAgHclbiAxPI86pBnwDX1tbzoiV8aFw==}
+    peerDependencies:
+      devtools-protocol: '*'
+
+  chromium-bidi@7.3.1:
+    resolution: {integrity: sha512-i+BMGluhZZc4Jic9L1aHJBTfaopxmCqQxGklyMcqFx4fvF3nI4BJ3bCe1ad474nvYRIo/ZN/VrdA4eOaRZua4Q==}
     peerDependencies:
       devtools-protocol: '*'
 
@@ -645,6 +678,9 @@ packages:
 
   devtools-protocol@0.0.1452169:
     resolution: {integrity: sha512-FOFDVMGrAUNp0dDKsAU1TorWJUx2JOU1k9xdgBKKJF3IBh/Uhl2yswG5r3TEAOrCiGY2QRp1e6LVDQrCsTKO4g==}
+
+  devtools-protocol@0.0.1475386:
+    resolution: {integrity: sha512-RQ809ykTfJ+dgj9bftdeL2vRVxASAuGU+I9LEx9Ij5TXU5HrgAQVmzi72VA+mkzscE12uzlRv5/tWWv9R9J1SA==}
 
   dom-serializer@1.4.1:
     resolution: {integrity: sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==}
@@ -1547,8 +1583,17 @@ packages:
     resolution: {integrity: sha512-CnzhOgrZj8DvkDqI+Yx+9or33i3Y9uUYbKyYpP4C13jWwXx/keQ38RMTMmxuLCWQlxjZrOH0Foq7P2fGP7adDQ==}
     engines: {node: '>=18'}
 
+  puppeteer-core@24.16.2:
+    resolution: {integrity: sha512-areKSSQzpoHa5nCk3uD/o504yjrW5ws0N6jZfdFZ3a4H+Q7NBgvuDydjN5P87jN4Rj+eIpLcK3ELOThTtYuuxg==}
+    engines: {node: '>=18'}
+
   puppeteer@24.10.2:
     resolution: {integrity: sha512-+k26rCz6akFZntx0hqUoFjCojgOLIxZs6p2k53LmEicwsT8F/FMBKfRfiBw1sitjiCvlR/15K7lBqfjXa251FA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  puppeteer@24.16.2:
+    resolution: {integrity: sha512-eNjKzwjITM4Lvho6iHb+VQamadUBgc8TsjAApsKi5N8DXipxAaAZWssBOFsrIOLo4eYWYj0Qk5gmr4wBSqzJWw==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -1605,8 +1650,8 @@ packages:
     resolution: {integrity: sha512-ZuF55hVUQaaczgOIwqWzkEcEidmlD/xl44x1UZnhOXcYuFN2S6+rcxpG+C1N3So0wvNI3DmJICUFfu2SxhBmvg==}
     deprecated: https://github.com/lydell/resolve-url#deprecated
 
-  respec@35.4.1:
-    resolution: {integrity: sha512-MAQpZ49We9vE4dbqr0zeFcO8q57VsjZcvtBGGEEe2bk/+KYIuw5wH7WJkhDDEf98fUQSPavMATqppdUkZjKoJg==}
+  respec@35.5.0:
+    resolution: {integrity: sha512-POjDng/tc07oP3dEreR1nGKGBBJlKnaa5ycAa4kwCV1JI0ZPlNIbUz1F/Ce9XuA7/L0Pl381OyTASmndfjDrXQ==}
     engines: {node: '>=20.12.1'}
     hasBin: true
 
@@ -1836,6 +1881,9 @@ packages:
   tar-fs@3.0.10:
     resolution: {integrity: sha512-C1SwlQGNLe/jPNqapK8epDsXME7CAJR5RL3GcE6KWx1d9OUByzoHVcbu1VPI8tevg9H8Alae0AApHHFGzrD5zA==}
 
+  tar-fs@3.1.0:
+    resolution: {integrity: sha512-5Mty5y/sOF1YWj1J6GiBodjlDc05CUR8PKXrsnFAiSG0xA+GHeWLovaZPYUDXkH/1iKRf2+M5+OrRgzC7O9b7w==}
+
   tar-stream@3.1.7:
     resolution: {integrity: sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==}
 
@@ -1984,6 +2032,18 @@ packages:
       utf-8-validate:
         optional: true
 
+  ws@8.18.3:
+    resolution: {integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
   y18n@4.0.3:
     resolution: {integrity: sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==}
 
@@ -2015,6 +2075,9 @@ packages:
 
   zod@3.25.67:
     resolution: {integrity: sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==}
+
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
 snapshots:
 
@@ -2201,6 +2264,19 @@ snapshots:
       - bare-buffer
       - supports-color
 
+  '@puppeteer/browsers@2.10.6':
+    dependencies:
+      debug: 4.4.1
+      extract-zip: 2.0.1
+      progress: 2.0.3
+      proxy-agent: 6.5.0
+      semver: 7.7.2
+      tar-fs: 3.1.0
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - bare-buffer
+      - supports-color
+
   '@sindresorhus/slugify@2.2.1':
     dependencies:
       '@sindresorhus/transliterate': 1.6.0
@@ -2329,11 +2405,21 @@ snapshots:
   bare-events@2.5.4:
     optional: true
 
+  bare-events@2.6.1:
+    optional: true
+
   bare-fs@4.1.5:
     dependencies:
       bare-events: 2.5.4
       bare-path: 3.0.0
       bare-stream: 2.6.5(bare-events@2.5.4)
+    optional: true
+
+  bare-fs@4.2.0:
+    dependencies:
+      bare-events: 2.6.1
+      bare-path: 3.0.0
+      bare-stream: 2.7.0(bare-events@2.6.1)
     optional: true
 
   bare-os@3.6.1:
@@ -2349,6 +2435,13 @@ snapshots:
       streamx: 2.22.1
     optionalDependencies:
       bare-events: 2.5.4
+    optional: true
+
+  bare-stream@2.7.0(bare-events@2.6.1):
+    dependencies:
+      streamx: 2.22.1
+    optionalDependencies:
+      bare-events: 2.6.1
     optional: true
 
   base@0.11.2:
@@ -2488,6 +2581,12 @@ snapshots:
       devtools-protocol: 0.0.1452169
       mitt: 3.0.1
       zod: 3.25.67
+
+  chromium-bidi@7.3.1(devtools-protocol@0.0.1475386):
+    dependencies:
+      devtools-protocol: 0.0.1475386
+      mitt: 3.0.1
+      zod: 3.25.76
 
   class-utils@0.3.6:
     dependencies:
@@ -2630,6 +2729,8 @@ snapshots:
     optional: true
 
   devtools-protocol@0.0.1452169: {}
+
+  devtools-protocol@0.0.1475386: {}
 
   dom-serializer@1.4.1:
     dependencies:
@@ -3565,6 +3666,20 @@ snapshots:
       - supports-color
       - utf-8-validate
 
+  puppeteer-core@24.16.2:
+    dependencies:
+      '@puppeteer/browsers': 2.10.6
+      chromium-bidi: 7.3.1(devtools-protocol@0.0.1475386)
+      debug: 4.4.1
+      devtools-protocol: 0.0.1475386
+      typed-query-selector: 2.12.0
+      ws: 8.18.3
+    transitivePeerDependencies:
+      - bare-buffer
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
   puppeteer@24.10.2:
     dependencies:
       '@puppeteer/browsers': 2.10.5
@@ -3572,6 +3687,21 @@ snapshots:
       cosmiconfig: 9.0.0
       devtools-protocol: 0.0.1452169
       puppeteer-core: 24.10.2
+      typed-query-selector: 2.12.0
+    transitivePeerDependencies:
+      - bare-buffer
+      - bufferutil
+      - supports-color
+      - typescript
+      - utf-8-validate
+
+  puppeteer@24.16.2:
+    dependencies:
+      '@puppeteer/browsers': 2.10.6
+      chromium-bidi: 7.3.1(devtools-protocol@0.0.1475386)
+      cosmiconfig: 9.0.0
+      devtools-protocol: 0.0.1475386
+      puppeteer-core: 24.16.2
       typed-query-selector: 2.12.0
     transitivePeerDependencies:
       - bare-buffer
@@ -3627,12 +3757,12 @@ snapshots:
 
   resolve-url@0.2.1: {}
 
-  respec@35.4.1:
+  respec@35.5.0:
     dependencies:
       colors: 1.4.0
       finalhandler: 2.1.0
       marked: 12.0.2
-      puppeteer: 24.10.2
+      puppeteer: 24.16.2
       sade: 1.8.1
       serve-static: 2.2.0
     transitivePeerDependencies:
@@ -3900,6 +4030,16 @@ snapshots:
     transitivePeerDependencies:
       - bare-buffer
 
+  tar-fs@3.1.0:
+    dependencies:
+      pump: 3.0.3
+      tar-stream: 3.1.7
+    optionalDependencies:
+      bare-fs: 4.2.0
+      bare-path: 3.0.0
+    transitivePeerDependencies:
+      - bare-buffer
+
   tar-stream@3.1.7:
     dependencies:
       b4a: 1.6.7
@@ -4025,6 +4165,8 @@ snapshots:
 
   ws@8.18.2: {}
 
+  ws@8.18.3: {}
+
   y18n@4.0.3: {}
 
   y18n@5.0.8: {}
@@ -4067,3 +4209,5 @@ snapshots:
       fd-slicer: 1.1.0
 
   zod@3.25.67: {}
+
+  zod@3.25.76: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,6 @@
 packages:
   - technical-reports
   - www
+
+onlyBuiltDependencies:
+  - puppeteer

--- a/technical-reports/package.json
+++ b/technical-reports/package.json
@@ -10,10 +10,14 @@
   },
   "scripts": {
     "build": "pnpm run build:index && pnpm run build:format && pnpm run build:color",
-    "build:index": "mkdir -p ../www/TR/drafts && respec index.html ../www/TR/drafts/index.html --localhost --disable-sandbox",
-    "build:format": "mkdir -p ../www/TR/drafts && mkdir -p ../www/TR/drafts/format && respec format/index.html ../www/TR/drafts/format/index.html --localhost --disable-sandbox",
-    "build:color": "mkdir -p ../www/TR/drafts && mkdir -p ../www/TR/drafts/color && respec color/index.html ../www/TR/drafts/color/index.html --localhost --disable-sandbox",
-    "dev": "chokidar \"**/*.{html,md}\" -c \"pnpm run build\" -d 2000",
+    "build:index": "pnpm run mkdirs && respec index.html ../www/TR/drafts/index.html --port 3001 --localhost --disable-sandbox",
+    "build:format": "pnpm run mkdirs && respec format/index.html ../www/TR/drafts/format/index.html --port 3002 --localhost --disable-sandbox",
+    "build:color": "pnpm run mkdirs && respec color/index.html ../www/TR/drafts/color/index.html --port 3003 --localhost --disable-sandbox",
+    "mkdirs": "mkdir -p ../www/TR/drafts && mkdir -p ../www/TR/drafts/format && mkdir -p ../www/TR/drafts/color",
+    "dev": "pnpm --parallel --filter @dtcg/tr run \"/^dev:.*/\"",
+    "dev:index": "pnpm run mkdirs && chokidar \"index.html\" -c \"pnpm run build:index\" -d 5000",
+    "dev:format": "pnpm run mkdirs && chokidar \"format/**/*\" -c \"pnpm run build:format\" -d 5000",
+    "dev:color": "pnpm run mkdirs && chokidar \"color/**/*\" -c \"pnpm run build:color\" -d 5000",
     "lint": "prettier . --check",
     "format": "prettier . --format --write",
     "validate": "pnpm run validate:index && pnpm run validate:format",
@@ -23,6 +27,6 @@
   "devDependencies": {
     "chokidar": "^4.0.3",
     "chokidar-cli": "^3.0.0",
-    "respec": "^35.4.1"
+    "respec": "^35.5.0"
   }
 }

--- a/www/.eleventy.js
+++ b/www/.eleventy.js
@@ -12,6 +12,8 @@ export default function (eleventyConfig) {
     () => `${new Date().getFullYear()}`,
   );
 
+  eleventyConfig.setUseGitIgnore(false);
+
   // Eleventy Navigation https://www.11ty.dev/docs/plugins/navigation/
   eleventyConfig.addPlugin(eleventyNavigationPlugin);
 
@@ -80,7 +82,6 @@ export default function (eleventyConfig) {
   eleventyConfig.addPassthroughCopy({
     admin: 'admin',
     public: '/',
-    TR: 'TR',
   });
   eleventyConfig.setServerPassthroughCopyBehavior('passthrough');
 
@@ -102,14 +103,14 @@ export default function (eleventyConfig) {
   eleventyConfig.setLibrary('md', mdit);
 
   return {
-    templateFormats: ['md', 'njk'],
+    templateFormats: ['md', 'njk', 'html'],
 
     // If your site lives in a different subdirectory, change this.
     // Leading or trailing slashes are all normalized away, so don’t worry about it.
     // If you don’t have a subdirectory, use "" or "/" (they do the same thing)
     // This is only used for URLs (it does not affect your file structure)
     pathPrefix: '/',
-    htmlTemplateEngine: 'njk',
+    htmlTemplateEngine: 'html',
     dataTemplateEngine: 'njk',
     dir: {
       input: '.',

--- a/www/.eleventyignore
+++ b/www/.eleventyignore
@@ -1,4 +1,3 @@
 README.md
-.github/
-**/*.scss
+.github/ \*_/_.scss
 ./.netlify/plugins/node_modules

--- a/www/package.json
+++ b/www/package.json
@@ -10,12 +10,10 @@
     "directory": "www"
   },
   "scripts": {
-    "build": "pnpm run build:tr && pnpm run build:sass && pnpm run build:eleventy",
-    "build:tr": "pnpm --filter @dtcg/tr run build",
+    "build": "pnpm run build:sass && pnpm run build:eleventy",
     "build:sass": "sass _includes:_site/_includes",
     "build:eleventy": "eleventy",
-    "dev": "pnpm --filter @dtcg/www --parallel --stream run \"/^dev:(eleventy|sass|tr)/\"",
-    "dev:tr": "pnpm --filter @dtcg/tr run build:watch",
+    "dev": "pnpm --filter @dtcg/www --parallel --stream run \"/^dev:(eleventy|sass)/\"",
     "dev:eleventy": "eleventy --serve --watch",
     "dev:sass": "pnpm --filter @dtcg/www run build:sass --watch",
     "lint": "prettier . --check",


### PR DESCRIPTION
## Changes

Followup from #293, where auto refresh can now be fixed in eleventy. Editing the draft spec now reflects changes in the local server without a restart.

There were a few problems fixed:

1. Eleventy’s passthrough behavior, for some reason, disables auto-refreshing (other static site builders allow for asset refreshing just fine).
2. Eleventy also has special handling for HTML, so we have to basically treat `.html` as an “input” so Eleventy auto-reloads and auto-builds when it changes. But we have to disable processing and other automatic things that would cause issues for us.
3. There was also some magic behavior we had to opt out of, such as Eleventy respecting `.gitignore` files

There was an optional improvement made where now **only the spec you’re editing rebuilds in `dev` mode.** As opposed to any change rebuilding all specs.

## How to Review

- ✅ Locally, editing a spec now reflects changes in local server (takes a few seconds for ReSpec to build, but that’s expected)
- ✅ The Netlify preview was expected, and the changes to the Eleventy config didn’t cause any regressions on the site
