### PR TITLE
fix(docs): don’t run htmlmin on ReSpec

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "lint": "pnpm --recursive --parallel --stream --if-present run lint",
     "format": "pnpm --recursive --parallel --stream --if-present run format",
     "prepare": "husky",
-    "install-browsers": "puppeteer browsers install chrome@137"
+    "install-browsers": "puppeteer browsers install chrome"
   },
   "lint-staged": {
     "*.{md,yml,json,html}": "prettier --write"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,8 +33,8 @@ importers:
         specifier: ^3.0.0
         version: 3.0.0
       respec:
-        specifier: ^35.5.0
-        version: 35.5.0
+        specifier: ^35.5.1
+        version: 35.5.1
 
   www:
     devDependencies:
@@ -1650,8 +1650,8 @@ packages:
     resolution: {integrity: sha512-ZuF55hVUQaaczgOIwqWzkEcEidmlD/xl44x1UZnhOXcYuFN2S6+rcxpG+C1N3So0wvNI3DmJICUFfu2SxhBmvg==}
     deprecated: https://github.com/lydell/resolve-url#deprecated
 
-  respec@35.5.0:
-    resolution: {integrity: sha512-POjDng/tc07oP3dEreR1nGKGBBJlKnaa5ycAa4kwCV1JI0ZPlNIbUz1F/Ce9XuA7/L0Pl381OyTASmndfjDrXQ==}
+  respec@35.5.1:
+    resolution: {integrity: sha512-F1ykHL5WdMXb6Rp5EGjaPsc34SSIl8GWFRKlkFZ+xNhsQrU5cN9OsnxWYqP/XO/0Kkeyj7JKn4pC1Ykrqnj7LQ==}
     engines: {node: '>=20.12.1'}
     hasBin: true
 
@@ -3757,7 +3757,7 @@ snapshots:
 
   resolve-url@0.2.1: {}
 
-  respec@35.5.0:
+  respec@35.5.1:
     dependencies:
       colors: 1.4.0
       finalhandler: 2.1.0

--- a/technical-reports/package.json
+++ b/technical-reports/package.json
@@ -27,6 +27,6 @@
   "devDependencies": {
     "chokidar": "^4.0.3",
     "chokidar-cli": "^3.0.0",
-    "respec": "^35.5.0"
+    "respec": "^35.5.1"
   }
 }

--- a/www/.eleventy.js
+++ b/www/.eleventy.js
@@ -67,15 +67,21 @@ export default function (eleventyConfig) {
 
   // Minify HTML output
   eleventyConfig.addTransform('htmlmin', function (content, outputPath) {
-    if (outputPath.indexOf('.html') > -1) {
-      let minified = htmlmin.minify(content, {
-        useShortDoctype: true,
-        removeComments: true,
-        collapseWhitespace: true,
-      });
-      return minified;
+    // only minify HTML
+    if (!outputPath.endsWith('.html')) {
+      return content;
     }
-    return content;
+
+    // don’t minify ReSpec
+    if (outputPath.toLowerCase().includes('/tr/')) {
+      return content;
+    }
+
+    return htmlmin.minify(content, {
+      useShortDoctype: true,
+      removeComments: true,
+      collapseWhitespace: true,
+    });
   });
 
   // Assets
@@ -83,7 +89,7 @@ export default function (eleventyConfig) {
     admin: 'admin',
     public: '/',
   });
-  eleventyConfig.setServerPassthroughCopyBehavior('passthrough');
+  eleventyConfig.setServerPassthroughCopyBehavior('passthrough'); // Allow hot reloading of assets
 
   /* Markdown Plugins */
   const mdit = markdownIt({


### PR DESCRIPTION
## Changes

Followup from #294—letting Eleventy process HTML leads to it minifying it, which removes some critical whitespace for ReSpec docs to display correctly. This is only a bugfix and does not affect any specifications or content.

**Before**

<img width="300" alt="CleanShot 2025-08-17 at 16 17 28@2x" src="https://github.com/user-attachments/assets/606306f4-1d13-4386-aea6-69e417d006dc" />

**After**

<img width="300" height="296" alt="CleanShot 2025-08-17 at 16 21 47@2x" src="https://github.com/user-attachments/assets/5a2ed954-722c-4f07-a6af-5a527f68e500" />



## How to Review

- ✅ Netlify preview looks improved.
