### PR TITLE
chore: Fix eleventy build errors on Windows hosts

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       chokidar-cli:
         specifier: ^3.0.0
         version: 3.0.0
+      mkdirp:
+        specifier: ^3.0.1
+        version: 3.0.1
       respec:
         specifier: ^35.5.1
         version: 35.5.1
@@ -1327,6 +1330,11 @@ packages:
   mixin-deep@1.3.2:
     resolution: {integrity: sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==}
     engines: {node: '>=0.10.0'}
+
+  mkdirp@3.0.1:
+    resolution: {integrity: sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==}
+    engines: {node: '>=10'}
+    hasBin: true
 
   moo@0.5.2:
     resolution: {integrity: sha512-iSAJLHYKnX41mKcJKjqvnAN9sf0LMDTXDEvFv+ffuRR9a1MIuXLjMNL6EsnDHSkKLTWNqQQ5uo61P4EbU4NU+Q==}
@@ -3407,6 +3415,8 @@ snapshots:
     dependencies:
       for-in: 1.0.2
       is-extendable: 1.0.1
+
+  mkdirp@3.0.1: {}
 
   moo@0.5.2: {}
 

--- a/technical-reports/package.json
+++ b/technical-reports/package.json
@@ -13,7 +13,7 @@
     "build:index": "pnpm run mkdirs && respec index.html ../www/TR/drafts/index.html --port 3001 --localhost --disable-sandbox",
     "build:format": "pnpm run mkdirs && respec format/index.html ../www/TR/drafts/format/index.html --port 3002 --localhost --disable-sandbox",
     "build:color": "pnpm run mkdirs && respec color/index.html ../www/TR/drafts/color/index.html --port 3003 --localhost --disable-sandbox",
-    "mkdirs": "mkdir -p ../www/TR/drafts && mkdir -p ../www/TR/drafts/format && mkdir -p ../www/TR/drafts/color",
+    "mkdirs": "mkdirp ../www/TR/drafts && mkdirp ../www/TR/drafts/format && mkdirp ../www/TR/drafts/color",
     "dev": "pnpm --parallel --filter @dtcg/tr run \"/^dev:.*/\"",
     "dev:index": "pnpm run mkdirs && chokidar \"index.html\" -c \"pnpm run build:index\" -d 5000",
     "dev:format": "pnpm run mkdirs && chokidar \"format/**/*\" -c \"pnpm run build:format\" -d 5000",
@@ -27,6 +27,7 @@
   "devDependencies": {
     "chokidar": "^4.0.3",
     "chokidar-cli": "^3.0.0",
+    "mkdirp": "^3.0.1",
     "respec": "^35.5.1"
   }
 }

--- a/www/posts/posts.11tydata.js
+++ b/www/posts/posts.11tydata.js
@@ -1,0 +1,7 @@
+export default {
+  layout: 'layouts/post.njk',
+  pageTitle: 'Blog',
+  permalink: (data) => `posts/${data.page.fileSlug}/index.html`,
+  author: 'Anonymous',
+  tags: ['post'],
+};

--- a/www/posts/posts.json
+++ b/www/posts/posts.json
@@ -1,7 +1,0 @@
-{
-  "layout": "layouts/post.njk",
-  "pageTitle": "Blog",
-  "permalink": "posts/{{ title | slug }}/index.html",
-  "author": "Anonymous",
-  "tags": ["post"]
-}


### PR DESCRIPTION
## Changes

_What does this PR change? Link to any related issue(s)._

The Eleventy build was broken when running on Windows machines due to assumptions about paths. Slugs are now normalised to prevent the build attempting to create paths with e.g. a colon `:` which is invalid on Windows.

I've also moved the calls to `mkdir -p` to use the `mkdirp` package - we could inline this as a pure node script, if preferred.

## How to Review

_How can a reviewer review your changes? What should be kept in mind for this review?_

If you have node and npm set up on a Windows machine, install dependencies, then run `pnpm run dev` or `pnpm run build`

Both commands should now work. Both commands should continue to work on existing supported platforms.
