### PR TITLE
fix: ReSpec config

### DIFF
--- a/technical-reports/resolver/index.html
+++ b/technical-reports/resolver/index.html
@@ -11,11 +11,12 @@
     <script class="remove">
       var respecConfig = {
         specStatus: 'CG-DRAFT',
+        isPreview: true,
+        subtitle: 'Preview',
         group: 'design-tokens',
-        // In PR preview apps, shows an annoying red box to the document,
-        // warning unsuspecting readers that they should not cite or
-        // reference this version of the specification.
-        isPreview: document.location.host.includes('preview'),
+        latestVersion: 'https://www.designtokens.org/TR/drafts/resolver/',
+        prevVersion: null,
+        edDraftURI: null,
         editors: [
           { name: 'Joren Broekema', url: 'https://code-workshop-kit.com/' },
           { name: 'Louis Chenais', url: 'https://bsky.app/profile/lucho.cool' },
@@ -27,7 +28,6 @@
           { name: 'Matthew Ström', url: 'https://matthewstrom.com' },
           { name: 'Lilith Whitman', url: 'https://github.com/LilithWittmann' },
         ],
-        shortName: 'design-tokens-resolvers',
         cg: 'Design Tokens W3C Community Group',
         cgURI: 'https://github.com/design-tokens/community-group',
         github: {
@@ -37,7 +37,7 @@
         tocIntroductory: true,
         logos: [
           {
-            src: '/_includes/assets/images/logo_128_2x.png',
+            src: '/assets/images/logo_128_2x.png',
             url: 'https://www.designtokens.org',
             alt: 'Design Tokens Community Group',
             width: 128,


### PR DESCRIPTION
## Changes

<img width="851" height="317" alt="CleanShot 2025-10-12 at 22 15 30@2x" src="https://github.com/user-attachments/assets/61b462f8-d322-4fad-88de-9b7a9a5248ef" />


- Fixes bad URLs in the Resolver module
- Fixes broken logo URL

## How to Review

- See preview URL
