### PR TITLE
fix: Hyma feedback for Resolver module

### DIFF
--- a/technical-reports/resolver/bundling.md
+++ b/technical-reports/resolver/bundling.md
@@ -37,7 +37,7 @@ Given a resolver that references 5 files:
       }
     }
   },
-  "composition": [
+  "resolutionOrder": [
     { "$ref": "#/sets/foundation" },
     { "$ref": "#/modifiers/theme" }
   ]
@@ -85,7 +85,7 @@ One could inline the contents, resulting in:
       }
     }
   },
-  "composition": [
+  "resolutionOrder": [
     { "$ref": "#/sets/foundation" },
     { "$ref": "#/modifiers/theme" }
   ]
@@ -100,9 +100,11 @@ Note that `foundation/colors.json` was referenced 3 times in the document, so in
 
 ## Using $defs for files
 
-As described in [$defs](#defs), `$defs` don’t have defined behavior in a resolver document. But they are valid pointers for [reference objects](#reference-objects). This strategy involves creating a top-level `$defs` key, with each top-level key containing the contents for that file.
+As described in [$defs](#defs), `$defs` don’t have defined behavior in a resolver document. They may only be used if a tool decides to support this feature of JSON Schema.
 
-There is no downside to using `$defs` other than the possibility of some tools not supporting it, since `$defs` is not a requirement of this spec.
+This strategy involves creating a top-level `$defs` key, with each top-level key containing the contents for that file.
+
+The only downside of using `$defs` is some tools may choose to ignore it, as it is not a minimum requirement of a resolver document.
 
 <aside class="example" title="Bundling by using $defs">
 
@@ -133,7 +135,7 @@ Given the same resolver [from the inlining section](#inlining-files), we can cre
       }
     }
   },
-  "composition": [
+  "resolutionOrder": [
     { "$ref": "#/sets/foundation" },
     { "$ref": "#/modifiers/theme" }
   ],

--- a/technical-reports/resolver/inputs.md
+++ b/technical-reports/resolver/inputs.md
@@ -12,7 +12,7 @@ Given the following modifiers:
 
 ```json
 {
-  "composition": [
+  "resolutionOrder": [
     {
       "type": "modifier",
       "name": "theme",

--- a/technical-reports/resolver/resolution-logic.md
+++ b/technical-reports/resolver/resolution-logic.md
@@ -3,7 +3,7 @@
 Tools MUST handle the resolution stages in order to produce the correct output.
 
 1. [Input validation](#input-validation): verifying the [input](#inputs) is valid for the given resolver document.
-2. [Composition](#composition-0): tracing the `composition` order to produce the final tokens structure.
+2. [Ordering](#ordering): tracing the `resolutionOrder` array to produce the final tokens structure.
 3. [Aliases](#aliases): resolving token aliases in the final tokens structure.
 4. [Resolution](#resolution-0): the final end result
 
@@ -11,7 +11,7 @@ Tools MUST handle the resolution stages in order to produce the correct output.
 
 Tools MUST require all [=inputs=] match the provided [modifier](#modifiers) contexts.
 
-If a resolver does NOT declare any modifiers, skip this step and proceed to [Composition](#composition-0).
+If a resolver does NOT declare any modifiers, skip this step and proceed to [ordering](#ordering).
 
 1. For every key in the input object:
    1. Verify it corresponds with a valid modifier. If it does not, throw an error.
@@ -19,16 +19,16 @@ If a resolver does NOT declare any modifiers, skip this step and proceed to [Com
 2. For every modifier in the resolver:
    1. If that resolver does NOT declare a default value, verify a key is provided in the input. If not, throw an error.
 
-## Composition
+## Ordering
 
-Tools MUST iterate over the [composition](#composition) array in order.
+Tools MUST iterate over the [resolutionOrder](#resolution-order) array in order.
 
 1. For every item in the array, determine whether it’s a [set](#sets) or [modifier](#modifiers), flattening into a single tokens structure in array order.
    1. If the item is a set, combine the `sources` in array order to produce a single tokens structure.
    1. Otherwise, if the item is a modifier, select only the `context` that matches the [input](#inputs), combining the array in order to produce a single tokens structure.
    1. In case of a conflict, take the most recent occurrence in the array.
 
-1. Repeat until you’ve reached the end of the composition array.
+1. Repeat until you’ve reached the end of the `resolutionOrder` array.
 
 The final result will be a tokens structure that behaves the same as if it were one source to begin with.
 
@@ -65,7 +65,7 @@ The final result will be a tokens structure that behaves the same as if it were 
       ]
     }
   },
-  "composition": [{ "$ref": "#/sets/foundation" }]
+  "resolutionOrder": [{ "$ref": "#/sets/foundation" }]
 }
 ```
 
@@ -90,7 +90,7 @@ Here, two `color.text.default` tokens were encountered. Since order matters, the
 
 Aliases MUST NOT be resolved until this step.
 
-After the [composition](#composition-0) has been flattened into a single tokens structure, the only remaining step is resolving aliases. Aliases are resolved the exact same way as outlined in the [format](../format/#aliases-references):
+After the [ordering](#ordering) has been flattened into a single tokens structure, the only remaining step is resolving aliases. Aliases are resolved the exact same way as outlined in the [format](../format/#aliases-references):
 
 - Deep aliases are allowed, so long as they’re not circular
 - An alias must point to the correct `$type`.
@@ -128,7 +128,7 @@ Resolver
       }
     }
   },
-  "composition": [
+  "resolutionOrder": [
     { "$ref": "#/sets/foundation" },
     { "$ref": "#/sets/components" },
     { "$ref": "#/modifiers/theme" }
@@ -184,7 +184,7 @@ themes/dark.json
 1. Input Validation
    1. Verify that `theme` is a defined modifier (it passes).
    1. Verify that `dark` is a valid value for the `theme` modifier (it passes).
-1. Composition
+1. Ordering
    1. The first item is the `foundation` set, providing `color.brand.primary`.
    2. The second item is the `components` set, providing `button.background` and `button.padding`.
    3. The third and final item is the `theme` modifier, providing `theme.accent`.

--- a/technical-reports/resolver/terminology.md
+++ b/technical-reports/resolver/terminology.md
@@ -2,7 +2,7 @@
 
 <section class="informative">
 
-## <dfn>Orthogonal</dfn> (orthogonality)
+## Orthogonality
 
 A trait describing two or more contexts that each operate on exclusive tokens, i.e. do not overlap. Modifiers MAY be orthogonal, but it are not required to be.
 
@@ -21,6 +21,6 @@ Since both modifiers provide a value for the `color.button` token, this means ar
 
 </section>
 
-## <dfn>Resolution</dfn>
+## Permutation
 
-A resolution is a single possible permutation of a resolver document. A resolution maps 1:1 to an [input](#inputs), but the difference is the “input” refers to the [modifier](#modifiers) contexts used, whereas “resolution” refers to the final set of tokens and token values produced.
+A permutation is a single possible permutation of a resolver document. A permutation maps 1:1 to an [input](#inputs), but the term “input” emphasizes the [modifier](#modifiers) contexts used, where “permutation” emphasizes the final set of tokens.


### PR DESCRIPTION
## Changes

Makes the following changes to the resolver module:

- ~composition~ → `resolutionOrder` (composition deemed too generic)
- Adds a note on minimum-required support for Reference objects
- ~resolution~ → permutation
- Clarifies tool responsibility around `$defs`

## How to Review

- These changes were done in a meeting with me + Hyma (Lilith, Mike, Marco)
- However, further input from DTCG editors is appreciated/welcome at this point!
- See Netlify preview
