### PR TITLE
fix tool links on site homepage

### DIFF
--- a/www/src/pages/index.astro
+++ b/www/src/pages/index.astro
@@ -9,7 +9,10 @@ const title = SITE_TITLE;
 <Base>
   <section class="hero-section">
     <p class="hero-eyebrow">
-      <a href="/technical-reports/" class="hero-eyebrow-link">
+      <a
+        href="https://www.w3.org/community/design-tokens/2025/10/28/design-tokens-specification-reaches-first-stable-version/"
+        class="hero-eyebrow-link"
+      >
         First stable version 2025.10 now available
       </a>
     </p>


### PR DESCRIPTION
## Changes

This PR fixes a number of broken links to tools on the site homepage. It also updates a number of links that currently return a permanent redirect status which will save visitors a server round trip.

## How to Review

Visit the URLs in question.
