### PR TITLE
Add Pinwheel as a design tool with DTCG JSON support

### DIFF
--- a/www/src/pages/faq.md
+++ b/www/src/pages/faq.md
@@ -75,6 +75,7 @@ Organizations building design tools and open-source projects are already shippin
 - [Knapsack](https://www.knapsack.cloud)
 - [Marvel](https://www.marvelapp.com)
 - [Penpot](https://www.penpot.com)
+- [Pinwheel](https://bjango.com/mac/pinwheel/)
 - [Sketch](https://www.sketch.com)
 - [Style Dictionary](https://www.styledictionary.com)
 - [Superposition](https://www.superposition.design)

--- a/www/src/pages/index.astro
+++ b/www/src/pages/index.astro
@@ -84,6 +84,7 @@ const title = SITE_TITLE;
           { name: 'Knapsack', link: 'https://www.knapsack.cloud' },
           { name: 'Marvel', link: 'https://marvelapp.com' },
           { name: 'Penpot', link: 'https://penpot.app' },
+          { name: 'Pinwheel', link: 'https://bjango.com/mac/pinwheel/' },
           { name: 'Sketch', link: 'https://www.sketch.com' },
           { name: 'Style Dictionary', link: 'https://styledictionary.com' },
           { name: 'Superposition', link: 'https://superposition.design' },


### PR DESCRIPTION
## Changes

This adds [Pinwheel](https://bjango.com/mac/pinwheel/) as a design tool with DTCG JSON support in the “Trusted by leading design tools” section of the [designtokens.org](designtokens.org) index page. Pinwheel has been added to its place in alphabetical order.


```
- [Penpot](https://www.penpot.com)
- [Pinwheel](https://bjango.com/mac/pinwheel/)
- [Sketch](https://www.sketch.com)
```

------

It has also been added to the “What tools support this?” section of the FAQ. Again, added to its place in alphabetical order.

```
          { name: 'Penpot', link: 'https://penpot.app' },
          { name: 'Pinwheel', link: 'https://bjango.com/mac/pinwheel/' },
          { name: 'Sketch', link: 'https://www.sketch.com' },
```