### PR TITLE
Fix version string in the resolver specification

### DIFF
--- a/technical-reports/resolver/syntax.md
+++ b/technical-reports/resolver/syntax.md
@@ -19,7 +19,7 @@ The document MAY provide a human-readable `name` at the root level. This is help
 
 ### Version
 
-The document MUST provide a version at the root level, and it MUST be `2025-11-01`. This is reserved for future versions in case breaking changes are introduced.
+The document MUST provide a version at the root level, and it MUST be `2025-10-01`. This is reserved for future versions in case breaking changes are introduced.
 
 ### Description
 


### PR DESCRIPTION
## Changes
Change the defined version string in the resolver specification from `2025-11-01` to `2025-10-01`.
The whole DTCG specification has the version 2025.10. The table above this change mentions that the version must be `2025-10-01`. So I assumed that the `2025-11-01` must be a typo.

## How to Review
Consider wether the version should be `2025-11-01` or `2025-10-01` and validate that the changed text has the correct version.