### PR TITLE
Fix version to be 2025.10

### DIFF
--- a/technical-reports/resolver/syntax.md
+++ b/technical-reports/resolver/syntax.md
@@ -7,7 +7,7 @@ A resolver document contains the following properties at the root level:
 | Name                                     | Type                                     | Required | Description                                     |
 | :--------------------------------------- | :--------------------------------------- | :------: | :---------------------------------------------- |
 | [**name**](#name)                        | `string`                                 |          | A short, human-readable name for the document.  |
-| [**version**](#version)                  | `YYYY-MM-DD`                             |    Y     | Version. Must be `2025-10-01`.                  |
+| [**version**](#version)                  | `YYYY.MM`                                |    Y     | Version. Must be `2025.10`.                     |
 | [**description**](#description)          | `string`                                 |          | A human-readable description for this document. |
 | [**sets**](#sets)                        | Map[`string`, Set]                       |          | Definition of sets.                             |
 | [**modifiers**](#modifiers)              | Map[`string, Modifier]                   |          | Definition of modifiers.                        |
@@ -19,7 +19,7 @@ The document MAY provide a human-readable `name` at the root level. This is help
 
 ### Version
 
-The document MUST provide a version at the root level, and it MUST be `2025-10-01`. This is reserved for future versions in case breaking changes are introduced.
+The document MUST provide a version at the root level, and it MUST be `2025.10`. This is reserved for future versions in case breaking changes are introduced.
 
 ### Description
 

--- a/www/src/pages/TR/2025.10/resolver/index.html
+++ b/www/src/pages/TR/2025.10/resolver/index.html
@@ -388,9 +388,9 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
 </tr>
 <tr>
 <td align="left"><a href="#version"><strong>version</strong></a></td>
-<td align="left"><code>YYYY-MM-DD</code></td>
+<td align="left"><code>YYYY.MM</code></td>
 <td align="center">Y</td>
-<td align="left">Version. Must be <code>2025-10-01</code>.</td>
+<td align="left">Version. Must be <code>2025.10</code>.</td>
 </tr>
 <tr>
 <td align="left"><a href="#description"><strong>description</strong></a></td>
@@ -420,7 +420,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
 <section id="name"><div class="header-wrapper"><h4 id="x4-1-1-name"><bdi class="secno">4.1.1 </bdi>Name</h4><a class="self-link" href="#name" aria-label="Permalink for Section 4.1.1"></a></div>
 <p>The document <em class="rfc2119">MAY</em> provide a human-readable <code>name</code> at the root level. This is helpful to distinguish one resolver document from another, in case the filename itself isn’t enough.</p>
 </section><section id="version"><div class="header-wrapper"><h4 id="x4-1-2-version"><bdi class="secno">4.1.2 </bdi>Version</h4><a class="self-link" href="#version" aria-label="Permalink for Section 4.1.2"></a></div>
-<p>The document <em class="rfc2119">MUST</em> provide a version at the root level, and it <em class="rfc2119">MUST</em> be <code>2025-11-01</code>. This is reserved for future versions in case breaking changes are introduced.</p>
+<p>The document <em class="rfc2119">MUST</em> provide a version at the root level, and it <em class="rfc2119">MUST</em> be <code>2025.10</code>. This is reserved for future versions in case breaking changes are introduced.</p>
 </section><section id="description"><div class="header-wrapper"><h4 id="x4-1-3-description"><bdi class="secno">4.1.3 </bdi>Description</h4><a class="self-link" href="#description" aria-label="Permalink for Section 4.1.3"></a></div>
 <p>The document <em class="rfc2119">MAY</em> provide a <code>description</code> at the root level. This may be used to add additional explanation or context not present in <a href="#name">name</a>.</p>
 </section><section id="sets"><div class="header-wrapper"><h4 id="x4-1-4-sets"><bdi class="secno">4.1.4 </bdi>Sets</h4><a class="self-link" href="#sets" aria-label="Permalink for Section 4.1.4"></a></div>


### PR DESCRIPTION
## Changes

Follow-up from #352 where a placeholder version slipped through final review, and the resolver module published with `YYYY-MM-DD` version instead of `YYYY.MM` version as originally-intended. Fortunately this has no current bearing on any tool behavior, but nonetheless we should correct it ASAP.

## How to Review

See diffs
