### PR TITLE
fix: correct JSON Pointer reference example in aliases spec

### DIFF
--- a/technical-reports/format/aliases.md
+++ b/technical-reports/format/aliases.md
@@ -66,11 +66,10 @@ For advanced use cases requiring access to specific properties within token valu
   },
   "semantic": {
     "primary": {
-      "$ref": "#/colors/blue/$value",
-      "$type": "color"
+      "$ref": "#/colors/blue"
     },
     "primaryHue": {
-      "$ref": "#/colors/blue/$value/components/0",
+      "$value": { "$ref": "#/colors/blue/$value/components/0" },
       "$type": "number"
     }
   }
@@ -81,8 +80,8 @@ For advanced use cases requiring access to specific properties within token valu
 
 In this example:
 
-- `"$ref": "#/colors/blue/$value"` is equivalent to `"{colors.blue}"`
-- `"$ref": "#/colors/blue/$value/components/0"` accesses just the red component (0) of the blue color
+- `"$ref": "#/colors/blue"` references the entire token, making `semantic.primary` an alias for `colors.blue`
+- `"$ref": "#/colors/blue/$value/components/0"` accesses just the first component (0) of the blue color
 
 **Key Differences:**
 


### PR DESCRIPTION
Example 32 incorrectly showed `$ref` at the token level pointing to `#/colors/blue/$value`, which would resolve to a value object without the `$value` wrapper, producing an invalid token structure.

Fixed by:
- Changing `semantic.primary` to reference `#/colors/blue` (the whole token) instead of `#/colors/blue/$value`
- Wrapping `semantic.primaryHue`'s `$ref` inside `$value` since it extracts a component value, not a whole token
