### PR TITLE
Add JSON Schema link to examples

### DIFF
--- a/technical-reports/color/color-type.md
+++ b/technical-reports/color/color-type.md
@@ -19,6 +19,7 @@ The `$value` property can then be used to specify the details of the color, The 
 
 ```json
 {
+  "$schema": "https://www.designtokens.org/schemas/2025.10/format.json",
   "Hot pink": {
     "$type": "color",
     "$value": {
@@ -56,6 +57,7 @@ The `none` keyword MAY be used in the `components` array to indicate that a comp
 
 ```json
 {
+  "$schema": "https://www.designtokens.org/schemas/2025.10/format.json",
   "White": {
     "$type": "color",
     "$value": {
@@ -76,6 +78,7 @@ Contrast this with the following example where the Hue is specified as `0`:
 
 ```json
 {
+  "$schema": "https://www.designtokens.org/schemas/2025.10/format.json",
   "White": {
     "$type": "color",
     "$value": {
@@ -338,7 +341,7 @@ The following values are supported for the `colorSpace` property. The `component
 
 <aside class="ednote" title="How does this conform to CSS Color Module 4?">
 <p>To provide a logically consistent approach without creating ambiguity around the format, this spec takes the following approach:</p>
-<ul> 
+<ul>
 <li>If CSS Color Module 4 allows a color space to be referenced by <strong>both</strong> a named function (like <code>srgb()</code>) <strong>and</strong> a keyword in the <code>color()</code> function, use the format intended for the <code>color()</code> function.</li>
 <li>If CSS Color Module 4 only defines a color space <strong>either</strong> as a named function (like <code>hwb()</code>) <strong>or</strong> a keyword in the <code>color()</code> function (like <code>rec-2020</code>), use the syntax indicated.</li>
 <li>If CSS Color Module 4 allows <strong>both</strong> unit values (like <code>50</code>) <strong>and</strong> percentages (like <code>50%</code>) for a component, use the unit value.</li>
@@ -362,6 +365,7 @@ sRGB was the standard color space for all CSS colors before CSS Color Module 4. 
 
 ```json
 {
+  "$schema": "https://www.designtokens.org/schemas/2025.10/format.json",
   "Hot pink": {
     "$type": "color",
     "$value": {
@@ -394,6 +398,7 @@ sRGB linear is a linearized version of sRGB. It is used in some design tools to 
 
 ```json
 {
+  "$schema": "https://www.designtokens.org/schemas/2025.10/format.json",
   "Hot pink": {
     "$type": "color",
     "$value": {
@@ -426,6 +431,7 @@ HSL is a [=color model=] that is a polar transformation of sRGB, supported as ea
 
 ```json
 {
+  "$schema": "https://www.designtokens.org/schemas/2025.10/format.json",
   "Hot pink": {
     "$type": "color",
     "$value": {
@@ -458,6 +464,7 @@ Another [=color model=], a polar transformation of sRGB.
 
 ```json
 {
+  "$schema": "https://www.designtokens.org/schemas/2025.10/format.json",
   "Hot pink": {
     "$type": "color",
     "$value": {
@@ -492,6 +499,7 @@ A and B are theoretically unbounded, but in practice don't exceed -160 to 160.
 
 ```json
 {
+  "$schema": "https://www.designtokens.org/schemas/2025.10/format.json",
   "Hot pink": {
     "$type": "color",
     "$value": {
@@ -526,6 +534,7 @@ The minimum value of C is `0`, which represents a neutral color (gray), and its 
 
 ```json
 {
+  "$schema": "https://www.designtokens.org/schemas/2025.10/format.json",
   "Hot pink": {
     "$type": "color",
     "$value": {
@@ -560,6 +569,7 @@ Like in CIELAB, A and B are theoretically unbounded, but in practice don't excee
 
 ```json
 {
+  "$schema": "https://www.designtokens.org/schemas/2025.10/format.json",
   "Hot pink": {
     "$type": "color",
     "$value": {
@@ -594,6 +604,7 @@ Like in LCH, the minimum value of Chroma is `0`, which represents a neutral colo
 
 ```json
 {
+  "$schema": "https://www.designtokens.org/schemas/2025.10/format.json",
   "Hot pink": {
     "$type": "color",
     "$value": {
@@ -626,6 +637,7 @@ Display P3 is a [=color space=] that is designed to be used in displays with a w
 
 ```json
 {
+  "$schema": "https://www.designtokens.org/schemas/2025.10/format.json",
   "Hot pink": {
     "$type": "color",
     "$value": {
@@ -658,6 +670,7 @@ A98 RGB is a color space that is designed to be used in displays with a wide col
 
 ```json
 {
+  "$schema": "https://www.designtokens.org/schemas/2025.10/format.json",
   "Hot pink": {
     "$type": "color",
     "$value": {
@@ -690,6 +703,7 @@ ProPhoto RGB is a color space that is designed to be used in displays with a wid
 
 ```json
 {
+  "$schema": "https://www.designtokens.org/schemas/2025.10/format.json",
   "Hot pink": {
     "$type": "color",
     "$value": {
@@ -723,6 +737,7 @@ Rec 2020 is a color space that is designed to be used in displays with a wide co
 
 ```json
 {
+  "$schema": "https://www.designtokens.org/schemas/2025.10/format.json",
   "Hot pink": {
     "$type": "color",
     "$value": {
@@ -755,6 +770,7 @@ XYZ-D65 is a color space that is designed to be able to represent all colors tha
 
 ```json
 {
+  "$schema": "https://www.designtokens.org/schemas/2025.10/format.json",
   "Hot pink": {
     "$type": "color",
     "$value": {
@@ -787,6 +803,7 @@ XYZ-D50 is similar to XYZ-D65, but uses the D50 illuminant.
 
 ```json
 {
+  "$schema": "https://www.designtokens.org/schemas/2025.10/format.json",
   "Hot pink": {
     "$type": "color",
     "$value": {

--- a/technical-reports/format/composite-types.md
+++ b/technical-reports/format/composite-types.md
@@ -24,6 +24,7 @@ For example, a shadow token with an array value can mix references to other shad
 
 ```json
 {
+  "$schema": "https://www.designtokens.org/schemas/2025.10/format.json",
   "layered-shadow": {
     "$type": "shadow",
     "$value": [
@@ -46,6 +47,7 @@ A design token whose type happens to be a composite type is sometimes also calle
 
 ```json
 {
+  "$schema": "https://www.designtokens.org/schemas/2025.10/format.json",
   "shadow-token": {
     "$type": "shadow",
     "$value": {
@@ -70,6 +72,7 @@ A design token whose type happens to be a composite type is sometimes also calle
 
 ```json
 {
+  "$schema": "https://www.designtokens.org/schemas/2025.10/format.json",
   "space": {
     "small": {
       "$type": "dimension",
@@ -159,6 +162,7 @@ These values have the same meaning as the equivalent ["line style" values in CSS
 
 ```json
 {
+  "$schema": "https://www.designtokens.org/schemas/2025.10/format.json",
   "focus-ring-style": {
     "$type": "strokeStyle",
     "$value": "dashed"
@@ -179,6 +183,7 @@ Object stroke style values MUST have the following properties:
 
 ```json
 {
+  "$schema": "https://www.designtokens.org/schemas/2025.10/format.json",
   "alert-border-style": {
     "$type": "strokeStyle",
     "$value": {
@@ -198,6 +203,7 @@ Object stroke style values MUST have the following properties:
 
 ```json
 {
+  "$schema": "https://www.designtokens.org/schemas/2025.10/format.json",
   "notification-border-style": {
     "$type": "strokeStyle",
     "$value": {
@@ -279,6 +285,7 @@ Represents a border style. The `$type` property MUST be set to the string `borde
 
 ```json
 {
+  "$schema": "https://www.designtokens.org/schemas/2025.10/format.json",
   "border": {
     "heavy": {
       "$type": "border",
@@ -333,6 +340,7 @@ Represents a animated transition between two states. The `$type` property MUST b
 
 ```json
 {
+  "$schema": "https://www.designtokens.org/schemas/2025.10/format.json",
   "transition": {
     "emphasis": {
       "$type": "transition",
@@ -374,6 +382,7 @@ Each shadow object (whether explicit or referenced) MUST have the following prop
 
 ```json
 {
+  "$schema": "https://www.designtokens.org/schemas/2025.10/format.json",
   "shadow-token": {
     "$type": "shadow",
     "$value": {
@@ -388,72 +397,73 @@ Each shadow object (whether explicit or referenced) MUST have the following prop
       "spread": { "value": 0, "unit": "rem" }
     }
   },
-"layered-shadow": {
-  "$type": "shadow",
-  "$value": [
-    {
-      "color": {
-        "colorSpace": "srgb",
-        "components": [0, 0, 0],
-        "alpha": 0.1
+  "layered-shadow": {
+    "$type": "shadow",
+    "$value": [
+      {
+        "color": {
+          "colorSpace": "srgb",
+          "components": [0, 0, 0],
+          "alpha": 0.1
+        },
+        "offsetX": { "value": 0, "unit": "px" },
+        "offsetY": { "value": 24, "unit": "px" },
+        "blur": { "value": 22, "unit": "px" },
+        "spread": { "value": 0, "unit": "px" }
       },
-      "offsetX": { "value": 0, "unit": "px" },
-      "offsetY": { "value": 24, "unit": "px" },
-      "blur": { "value": 22, "unit": "px" },
-      "spread": { "value": 0, "unit": "px" }
-    },
-    {
-      "color": {
-        "colorSpace": "srgb",
-        "components": [0, 0, 0],
-        "alpha": 0.2
+      {
+        "color": {
+          "colorSpace": "srgb",
+          "components": [0, 0, 0],
+          "alpha": 0.2
+        },
+        "offsetX": { "value": 0, "unit": "px" },
+        "offsetY": { "value": 42.9, "unit": "px" },
+        "blur": { "value": 44, "unit": "px" },
+        "spread": { "value": 0, "unit": "px" }
       },
-      "offsetX": { "value": 0, "unit": "px" },
-      "offsetY": { "value": 42.9, "unit": "px" },
-      "blur": { "value": 44, "unit": "px" },
-      "spread": { "value": 0, "unit": "px" }
-    },
-    {
-      "color": {
-        "colorSpace": "srgb",
-        "components": [0, 0, 0],
-        "alpha": 0.3
-      },
-      "offsetX": { "value": 0, "unit": "px" },
-      "offsetY": { "value": 64, "unit": "px" },
-      "blur": { "value": 64, "unit": "px" },
-      "spread": { "value": 0, "unit": "px" }
-    }
-  ]
-},
+      {
+        "color": {
+          "colorSpace": "srgb",
+          "components": [0, 0, 0],
+          "alpha": 0.3
+        },
+        "offsetX": { "value": 0, "unit": "px" },
+        "offsetY": { "value": 64, "unit": "px" },
+        "blur": { "value": 64, "unit": "px" },
+        "spread": { "value": 0, "unit": "px" }
+      }
+    ]
+  },
 
-"mixed-reference-shadow": {
-  "$type": "shadow",
-  "$value": [
-    "{base.shadow}",
-    {
-      "color": "{brand.accent}",
+  "mixed-reference-shadow": {
+    "$type": "shadow",
+    "$value": [
+      "{base.shadow}",
+      {
+        "color": "{brand.accent}",
+        "offsetX": { "value": 2, "unit": "px" },
+        "offsetY": { "value": 2, "unit": "px" },
+        "blur": { "value": 4, "unit": "px" },
+        "spread": { "value": 1, "unit": "px" }
+      },
+      "{highlight.shadow}"
+    ]
+  },
+  "inner-shadow": {
+    "$type": "shadow",
+    "$value": {
+      "color": {
+        "colorSpace": "srgb",
+        "components": [0, 0, 0],
+        "alpha": 0.5
+      },
       "offsetX": { "value": 2, "unit": "px" },
       "offsetY": { "value": 2, "unit": "px" },
       "blur": { "value": 4, "unit": "px" },
-      "spread": { "value": 1, "unit": "px" }
-    },
-    "{highlight.shadow}"
-  ]
-}
-"inner-shadow": {
-  "$type": "shadow",
-  "$value": {
-    "color": {
-      "colorSpace": "srgb",
-      "components": [0, 0, 0],
-      "alpha": 0.5
-    },
-    "offsetX": { "value": 2, "unit": "px" },
-    "offsetY": { "value": 2, "unit": "px" },
-    "blur": { "value": 4, "unit": "px" },
-    "spread": { "value": 0, "unit": "px" },
-    "inset": true
+      "spread": { "value": 0, "unit": "px" },
+      "inset": true
+    }
   }
 }
 ```
@@ -479,6 +489,7 @@ If there are no stops at the very beginning or end of the gradient axis (i.e. wi
 
 ```json
 {
+  "$schema": "https://www.designtokens.org/schemas/2025.10/format.json",
   "blue-to-red": {
     "$type": "gradient",
     "$value": [
@@ -511,6 +522,7 @@ Describes a gradient that goes from blue to red:
 
 ```json
 {
+  "$schema": "https://www.designtokens.org/schemas/2025.10/format.json",
   "mostly-yellow": {
     "$type": "gradient",
     "$value": [
@@ -543,6 +555,7 @@ Describes a gradient that is solid yellow for the first 2/3 and then fades to re
 
 ```json
 {
+  "$schema": "https://www.designtokens.org/schemas/2025.10/format.json",
   "brand-primary": {
     "$type": "color",
     "$value": {
@@ -639,6 +652,7 @@ Represents a typographic style. The `$type` property MUST be set to the string `
 
 ```json
 {
+  "$schema": "https://www.designtokens.org/schemas/2025.10/format.json",
   "type styles": {
     "heading-level-1": {
       "$type": "typography",

--- a/technical-reports/format/types.md
+++ b/technical-reports/format/types.md
@@ -29,6 +29,7 @@ For example:
 
 ```json
 {
+  "$schema": "https://www.designtokens.org/schemas/2025.10/format.json",
   "spacing-stack-0": {
     "$value": {
       "value": 0,
@@ -71,6 +72,7 @@ For example:
 
 ```json
 {
+  "$schema": "https://www.designtokens.org/schemas/2025.10/format.json",
   "Primary font": {
     "$value": "Comic Sans MS",
     "$type": "fontFamily"
@@ -111,6 +113,7 @@ Example:
 
 ```json
 {
+  "$schema": "https://www.designtokens.org/schemas/2025.10/format.json",
   "font-weight-default": {
     "$value": 350,
     "$type": "fontWeight"
@@ -139,6 +142,7 @@ For example:
 
 ```json
 {
+  "$schema": "https://www.designtokens.org/schemas/2025.10/format.json",
   "Duration-Quick": {
     "$value": {
       "value": 100,
@@ -169,6 +173,7 @@ For example:
 
 ```json
 {
+  "$schema": "https://www.designtokens.org/schemas/2025.10/format.json",
   "Accelerate": {
     "$value": [0.5, 0, 1, 1],
     "$type": "cubicBezier"
@@ -190,6 +195,7 @@ Represents a number. Numbers can be positive, negative and have fractions. Examp
 
 ```json
 {
+  "$schema": "https://www.designtokens.org/schemas/2025.10/format.json",
   "line-height-large": {
     "$value": 2.3,
     "$type": "number"

--- a/www/src/pages/glossary.md
+++ b/www/src/pages/glossary.md
@@ -18,6 +18,7 @@ The value of `color.text.primary` is `#000000`, because it references `color.pal
 
 ```json
 {
+  "$schema": "https://www.designtokens.org/schemas/2025.10/format.json",
   "color": {
     "palette": {
       "black": {


### PR DESCRIPTION
## Changes

Adds the JSON Schema link to examples wherever possible (I may have missed some, but this adds to the vast majority).

The reasoning is that folks will probably land on this-or-that example, and rarely anyone will read top-to-bottom. So adding to every example not only increases visibility, but also, by adding it everywhere, hopefully it becomes “invisible” because folks just know to ignore that line. Hopefully.

I think this may be worth promoting to the official 2025.10 spec after this merges, just because this is non-normative.

## How to Review

- See preview link
