### PR TITLE
fix: header border

### DIFF
--- a/www/src/components/Header.astro
+++ b/www/src/components/Header.astro
@@ -57,6 +57,7 @@ const url = new URL(Astro.request.url);
     align-items: center;
     background-color: var(--color-bg);
     border-block-end: 1px solid var(--color-border);
+    box-sizing: content-box;
     display: flex;
     gap: var(--base-space-4);
     height: var(--header-height);
@@ -71,7 +72,7 @@ const url = new URL(Astro.request.url);
     background-color: var(--color-bg);
     display: flex;
     flex-direction: row;
-    height: calc(var(--header-height) + 1px);
+    height: var(--header-height);
     padding: 0;
   }
 


### PR DESCRIPTION
## Changes

Fixes an accidental “off by 1 (pixel)” error in CSS.

**Before**

<img width="1346" height="212" alt="CleanShot 2026-01-13 at 09 44 43@2x" src="https://github.com/user-attachments/assets/8f86ea62-24a3-4996-a611-d122f3292468" />

**After**

<img width="1426" height="388" alt="CleanShot 2026-01-13 at 09 50 21@2x" src="https://github.com/user-attachments/assets/51910210-3b9c-4618-874a-50ab266e7f68" />


## How to Review

- See screenshots
- Verified working in deploy preview