### PR TITLE
JSON schema references fix in non-composite tokens

### DIFF
--- a/www/public/schemas/2025.10/format/values/color.json
+++ b/www/public/schemas/2025.10/format/values/color.json
@@ -45,7 +45,7 @@
           "maximum": 1
         },
         {
-          "$ref": "../../format.json#/definitions/tokenValueReference"
+          "$ref": "../../format.json#/definitions/jsonPointerReferenceObject"
         }
       ]
     },
@@ -80,7 +80,7 @@
           "const": "none"
         },
         {
-          "$ref": "../../format.json#/definitions/tokenValueReference"
+          "$ref": "../../format.json#/definitions/jsonPointerReferenceObject"
         }
       ]
     },
@@ -98,7 +98,7 @@
           "const": "none"
         },
         {
-          "$ref": "../../format.json#/definitions/tokenValueReference"
+          "$ref": "../../format.json#/definitions/jsonPointerReferenceObject"
         }
       ]
     },
@@ -116,7 +116,7 @@
           "const": "none"
         },
         {
-          "$ref": "../../format.json#/definitions/tokenValueReference"
+          "$ref": "../../format.json#/definitions/jsonPointerReferenceObject"
         }
       ]
     },
@@ -133,7 +133,7 @@
           "const": "none"
         },
         {
-          "$ref": "../../format.json#/definitions/tokenValueReference"
+          "$ref": "../../format.json#/definitions/jsonPointerReferenceObject"
         }
       ]
     },
@@ -149,7 +149,7 @@
           "const": "none"
         },
         {
-          "$ref": "../../format.json#/definitions/tokenValueReference"
+          "$ref": "../../format.json#/definitions/jsonPointerReferenceObject"
         }
       ]
     },

--- a/www/public/schemas/2025.10/format/values/cubicBezier.json
+++ b/www/public/schemas/2025.10/format/values/cubicBezier.json
@@ -36,7 +36,7 @@
           "maximum": 1
         },
         {
-          "$ref": "../../format.json#/definitions/tokenValueReference"
+          "$ref": "../../format.json#/definitions/jsonPointerReferenceObject"
         }
       ]
     },
@@ -48,7 +48,7 @@
           "type": "number"
         },
         {
-          "$ref": "../../format.json#/definitions/tokenValueReference"
+          "$ref": "../../format.json#/definitions/jsonPointerReferenceObject"
         }
       ]
     }

--- a/www/public/schemas/2025.10/format/values/dimension.json
+++ b/www/public/schemas/2025.10/format/values/dimension.json
@@ -12,7 +12,7 @@
           "type": "number"
         },
         {
-          "$ref": "../../format.json#/definitions/tokenValueReference"
+          "$ref": "../../format.json#/definitions/jsonPointerReferenceObject"
         }
       ]
     },

--- a/www/public/schemas/2025.10/format/values/duration.json
+++ b/www/public/schemas/2025.10/format/values/duration.json
@@ -12,7 +12,7 @@
           "type": "number"
         },
         {
-          "$ref": "../../format.json#/definitions/tokenValueReference"
+          "$ref": "../../format.json#/definitions/jsonPointerReferenceObject"
         }
       ]
     },


### PR DESCRIPTION
## Changes

This PR fixes a bug in the JSON schema where curly brace references were allowed within sub-values of non-composite tokens (which is not allowed). See #383 for discussion. Only composite tokens explicitly allow curly brace references in sub-values according to the specification [here](https://www.designtokens.org/tr/2025.10/format/#composite-types).

## How to Review
- Review the JSON schema of the non-composite token types and make sure that within them only the `jsonPointerReferenceObject` definition is used but not the `tokenValueReference` definition (as the `tokenValueReference`  allows for both a `curlyBraceReference` as well as a `jsonPointerReferenceObject`).
- Test with a design token file which incorrectly has a curly brace reference in a sub-value of a non-composite token and check wether the schema properly flags it.