### PR TITLE
Serve JSON Schema files with the correct MIME type

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -15,3 +15,9 @@
   pretty_urls = true
 [build.processing.images]
   compress = true
+
+# Serve JSON Schema files with the correct MIME type
+[[headers]]
+  for = "/schemas/**/*.json"
+  [headers.values]
+    Content-Type = "application/schema+json"


### PR DESCRIPTION
## Changes

Changes the MIME type of JSON files located in the `/schemas/` folder to `application/schema+json`. It is the correct mime type for json schemas and some json schema tools expect the mime type to be `application/schema+json` to work properly. (I recently tried to use the bundler of https://github.com/hyperjump-io/json-schema and it did not work by default with the hosted version of the design tokens JSON schema because it did not have the appropriate mime type).

## How to Review

When deployed check if the JSON schemas served from the `/schemas/` folder have the `application/schema+json` mime type.
