### PR TITLE
Allow whole array aliasing in JSON schema

### DIFF
--- a/www/public/schemas/2025.10/format/values/color.json
+++ b/www/public/schemas/2025.10/format/values/color.json
@@ -34,7 +34,14 @@
     },
     "components": {
       "description": "Array of color components. The number and meaning of components depend on the color space. Each component can be a number or the 'none' keyword.",
-      "type": "array"
+      "oneOf": [
+        {
+          "type": "array"
+        },
+        {
+          "$ref": "../../format.json#/definitions/jsonPointerReferenceObject"
+        }
+      ]
     },
     "alpha": {
       "description": "The alpha (transparency) value of the color. 0 is fully transparent, 1 is fully opaque. If omitted, defaults to 1.",
@@ -200,7 +207,8 @@
     {
       "if": {
         "properties": {
-          "colorSpace": { "const": "srgb" }
+          "colorSpace": { "const": "srgb" },
+          "components": { "type": "array" }
         }
       },
       "then": {
@@ -214,7 +222,8 @@
     {
       "if": {
         "properties": {
-          "colorSpace": { "const": "srgb-linear" }
+          "colorSpace": { "const": "srgb-linear" },
+          "components": { "type": "array" }
         }
       },
       "then": {
@@ -228,7 +237,8 @@
     {
       "if": {
         "properties": {
-          "colorSpace": { "const": "display-p3" }
+          "colorSpace": { "const": "display-p3" },
+          "components": { "type": "array" }
         }
       },
       "then": {
@@ -242,7 +252,8 @@
     {
       "if": {
         "properties": {
-          "colorSpace": { "const": "a98-rgb" }
+          "colorSpace": { "const": "a98-rgb" },
+          "components": { "type": "array" }
         }
       },
       "then": {
@@ -256,7 +267,8 @@
     {
       "if": {
         "properties": {
-          "colorSpace": { "const": "prophoto-rgb" }
+          "colorSpace": { "const": "prophoto-rgb" },
+          "components": { "type": "array" }
         }
       },
       "then": {
@@ -270,7 +282,8 @@
     {
       "if": {
         "properties": {
-          "colorSpace": { "const": "rec2020" }
+          "colorSpace": { "const": "rec2020" },
+          "components": { "type": "array" }
         }
       },
       "then": {
@@ -284,7 +297,8 @@
     {
       "if": {
         "properties": {
-          "colorSpace": { "const": "xyz-d65" }
+          "colorSpace": { "const": "xyz-d65" },
+          "components": { "type": "array" }
         }
       },
       "then": {
@@ -298,7 +312,8 @@
     {
       "if": {
         "properties": {
-          "colorSpace": { "const": "xyz-d50" }
+          "colorSpace": { "const": "xyz-d50" },
+          "components": { "type": "array" }
         }
       },
       "then": {
@@ -312,7 +327,8 @@
     {
       "if": {
         "properties": {
-          "colorSpace": { "const": "hsl" }
+          "colorSpace": { "const": "hsl" },
+          "components": { "type": "array" }
         }
       },
       "then": {
@@ -342,7 +358,8 @@
     {
       "if": {
         "properties": {
-          "colorSpace": { "const": "hwb" }
+          "colorSpace": { "const": "hwb" },
+          "components": { "type": "array" }
         }
       },
       "then": {
@@ -372,7 +389,8 @@
     {
       "if": {
         "properties": {
-          "colorSpace": { "const": "lab" }
+          "colorSpace": { "const": "lab" },
+          "components": { "type": "array" }
         }
       },
       "then": {
@@ -402,7 +420,8 @@
     {
       "if": {
         "properties": {
-          "colorSpace": { "const": "lch" }
+          "colorSpace": { "const": "lch" },
+          "components": { "type": "array" }
         }
       },
       "then": {
@@ -432,7 +451,8 @@
     {
       "if": {
         "properties": {
-          "colorSpace": { "const": "oklab" }
+          "colorSpace": { "const": "oklab" },
+          "components": { "type": "array" }
         }
       },
       "then": {
@@ -462,7 +482,8 @@
     {
       "if": {
         "properties": {
-          "colorSpace": { "const": "oklch" }
+          "colorSpace": { "const": "oklch" },
+          "components": { "type": "array" }
         }
       },
       "then": {

--- a/www/public/schemas/2025.10/format/values/strokeStyle.json
+++ b/www/public/schemas/2025.10/format/values/strokeStyle.json
@@ -22,19 +22,26 @@
       "type": "object",
       "properties": {
         "dashArray": {
-          "type": "array",
           "description": "Array of dimension values specifying lengths of alternating dashes and gaps",
-          "items": {
-            "oneOf": [
-              {
-                "$ref": "dimension.json"
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "oneOf": [
+                  {
+                    "$ref": "dimension.json"
+                  },
+                  {
+                    "$ref": "../../format.json#/definitions/tokenValueReference"
+                  }
+                ]
               },
-              {
-                "$ref": "../../format.json#/definitions/tokenValueReference"
-              }
-            ]
-          },
-          "minItems": 1
+              "minItems": 1
+            },
+            {
+              "$ref": "../../format.json#/definitions/jsonPointerReferenceObject"
+            }
+          ]
         },
         "lineCap": {
           "description": "Line cap style, same meaning as SVG stroke-linecap attribute",


### PR DESCRIPTION
## Changes

Another small fix to the JSON schema. For the color and strokeStyle token values the JSON schema previously did not allow for the whole array in those schemas to be referenced with a JSON pointer. I.e.

```json
{
  "colors": {
    "$type": "color",
    "base-blue": {
      "$value": {
        "colorSpace": "srgb",
        "components": [0.2, 0.4, 0.9]
      }
    },
    "derived-same-components": {
      "$description": "References the entire components array from base-blue",
      "$value": {
        "colorSpace": "srgb",
        "components": { "$ref": "#/colors/base-blue/$value/components" }
      }
    }
  }
}
```
was not allowed before but from my understanding it should be allowed.

In the color value schema since the components can now be an array or an object I needed to refine the `if` statements to check for the color space and wether the components are an array (so it does not try to apply color space rules on components that are a JSON pointer reference).

## How to Review
Verify if the schema now properly allows referencing whole arrays within color and strokeStyle values. Also verify that that this change did not break any valid uses of color or strokeStyle values.
