### PR TITLE
Fix outdated links to Style Dictionary

### DIFF
--- a/www/src/pages/TR/first-editors-draft/format/index.html
+++ b/www/src/pages/TR/first-editors-draft/format/index.html
@@ -413,7 +413,7 @@
   <p>Few examples:</p>
   <ul>
   <li><a href="https://github.com/salesforce-ux/theo">Theo</a></li>
-  <li><a href="https://amzn.github.io/style-dictionary/">Style Dictionary</a></li>
+  <li><a href="https://github.com/style-dictionary/style-dictionary">Style Dictionary</a></li>
   <li><a href="https://diez.org/">Diez</a></li>
   <li><a href="https://specifyapp.com/">Specify</a></li>
   </ul>
@@ -755,7 +755,7 @@
   <p><img src="https://d33wubrfki0l68.cloudfront.net/758c21846c4c036a407c20fd63d9deb2ec9356e6/5e83b/group-progressive-disclosure.png" alt="Progressive disclosure groups" height="426" width="506"></p>
   </section><section id="export-tools"><div class="header-wrapper"><h4 id="x6-2-3-export-tools"><bdi class="secno">6.2.3 </bdi>Export tools</h4><a class="self-link" href="#export-tools" aria-label="Permalink for Section 6.2.3"></a></div>
   <p>Token names are not guaranteed to be unique within the same file. The same name can be used in different groups. Also, export tools may need to export design tokens in a uniquely identifiable way, such as variables in code. Export tools should therefore use design tokens' paths as these <em>are</em> unique within a file.</p>
-  <p>For example, a <a href="#translation-tool">translation tool</a> like <a href="https://amzn.github.io/style-dictionary/">Style Dictionary</a> might use the following design token file:</p>
+  <p>For example, a <a href="#translation-tool">translation tool</a> like <a href="https://github.com/style-dictionary/style-dictionary">Style Dictionary</a> might use the following design token file:</p>
   <aside class="example" id="example-8"><div class="marker">
       <a class="self-link" href="#example-8">Example<bdi> 8</bdi></a>
     </div>

--- a/www/src/pages/TR/second-editors-draft/format/index.html
+++ b/www/src/pages/TR/second-editors-draft/format/index.html
@@ -428,7 +428,7 @@
   <p>For example:</p>
   <ul>
   <li><a href="https://github.com/salesforce-ux/theo">Theo</a></li>
-  <li><a href="https://amzn.github.io/style-dictionary/">Style Dictionary</a></li>
+  <li><a href="https://github.com/style-dictionary/style-dictionary">Style Dictionary</a></li>
   <li><a href="https://diez.org/">Diez</a></li>
   <li><a href="https://specifyapp.com/">Specify</a></li>
   </ul>
@@ -878,7 +878,7 @@
   <p><img src="./group-progressive-disclosure.png" alt="Progressive disclosure groups" height="426" width="506"></p>
   </section><section id="export-tools"><div class="header-wrapper"><h4 id="x6-2-3-export-tools"><bdi class="secno">6.2.3 </bdi>Export tools</h4><a class="self-link" href="#export-tools" aria-label="Permalink for Section 6.2.3"></a></div>
   <p>Token names are not guaranteed to be unique within the same file. The same name can be used in different groups. Also, export tools <em class="rfc2119">MAY</em> need to export design tokens in a uniquely identifiable way, such as variables in code. Export tools <em class="rfc2119">SHOULD</em> therefore use design tokens' paths as these <em>are</em> unique within a file.</p>
-  <p>For example, a <a data-link-type="dfn" href="#dfn-translation-tool" class="internalDFN" id="ref-for-dfn-translation-tool-4">translation tool</a> like <a href="https://amzn.github.io/style-dictionary/">Style Dictionary</a> might use the following design token file:</p>
+  <p>For example, a <a data-link-type="dfn" href="#dfn-translation-tool" class="internalDFN" id="ref-for-dfn-translation-tool-4">translation tool</a> like <a href="https://github.com/style-dictionary/style-dictionary">Style Dictionary</a> might use the following design token file:</p>
   <aside class="example" id="example-12"><div class="marker">
       <a class="self-link" href="#example-12">Example<bdi> 12</bdi></a>
     </div>

--- a/www/src/pages/TR/third-editors-draft/format/index.html
+++ b/www/src/pages/TR/third-editors-draft/format/index.html
@@ -452,7 +452,7 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
 <p>Design token translation tools translate token data from one format to another.</p>
 <p>For example:</p>
 <ul>
-<li><a href="https://amzn.github.io/style-dictionary/">Style Dictionary</a></li>
+<li><a href="https://github.com/style-dictionary/style-dictionary">Style Dictionary</a></li>
 <li><a href="https://github.com/terrazzoapp/terrazzo">Terrazzo</a></li>
 <li>...</li>
 </ul>
@@ -1165,7 +1165,7 @@ $font-size: 16px;
 
 </section><section id="translation-tools"><div class="header-wrapper"><h4 id="x6-2-3-translation-tools"><bdi class="secno">6.2.3 </bdi>Translation tools</h4><a class="self-link" href="#translation-tools" aria-label="Permalink for Section 6.2.3"></a></div>
 <p>Token names are not guaranteed to be unique within the same file. The same name can be used in different groups. Also, translation tools <em class="rfc2119">MAY</em> need to export design tokens in a uniquely identifiable way, such as variables in code. Translation tools <em class="rfc2119">SHOULD</em> therefore use design tokens' paths as these <em>are</em> unique within a file.</p>
-<p>For example, a <a data-link-type="dfn|abstract-op" href="#dfn-translation-tool" class="internalDFN" id="ref-for-dfn-translation-tool-4">translation tool</a> like <a href="https://amzn.github.io/style-dictionary/">Style Dictionary</a> might use the following design token file:</p>
+<p>For example, a <a data-link-type="dfn|abstract-op" href="#dfn-translation-tool" class="internalDFN" id="ref-for-dfn-translation-tool-4">translation tool</a> like <a href="https://github.com/style-dictionary/style-dictionary">Style Dictionary</a> might use the following design token file:</p>
 <aside class="example" id="example-17"><div class="marker">
     <a class="self-link" href="#example-17">Example<bdi> 17</bdi></a>
   </div>


### PR DESCRIPTION
## Changes

This PR follows up on https://github.com/design-tokens/community-group/pull/353 and updates the remaining references to Style Dictionary by replacing outdated links with https://github.com/style-dictionary/style-dictionary.

## How to Review

The codebase was searched for all occurrences matching the `amzn.github.io` pattern. Each instance of https://amzn.github.io/style-dictionary/ has been replaced with https://github.com/style-dictionary/style-dictionary.

No functional changes: link updates only.