### PR TITLE
fix: DTCG playground

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,9 +41,6 @@ importers:
 
   www:
     dependencies:
-      '@monaco-editor/react':
-        specifier: ^4.7.0
-        version: 4.7.0(monaco-editor@0.55.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       fast-deep-equal:
         specifier: ^3.1.3
         version: 3.1.3
@@ -51,18 +48,18 @@ importers:
         specifier: ^0.55.1
         version: 0.55.1
       nanoid:
-        specifier: ^5.1.6
-        version: 5.1.6
+        specifier: ^5.1.9
+        version: 5.1.9
       preact:
-        specifier: 11.0.0-beta.0
-        version: 11.0.0-beta.0
+        specifier: 10.29.1
+        version: 10.29.1
     devDependencies:
       '@astrojs/mdx':
         specifier: ^5.0.4
         version: 5.0.4(astro@6.1.9(@types/node@24.10.1)(lightningcss@1.30.2)(rollup@4.60.1)(sass@1.99.0)(typescript@5.9.2)(yaml@2.8.2))
       '@astrojs/preact':
         specifier: ^5.1.2
-        version: 5.1.2(@babel/core@7.28.5)(@types/node@24.10.1)(lightningcss@1.30.2)(preact@11.0.0-beta.0)(rollup@4.60.1)(sass@1.99.0)(yaml@2.8.2)
+        version: 5.1.2(@babel/core@7.28.5)(@types/node@24.10.1)(lightningcss@1.30.2)(preact@10.29.1)(rollup@4.60.1)(sass@1.99.0)(yaml@2.8.2)
       '@astrojs/rss':
         specifier: ^4.0.18
         version: 4.0.18
@@ -103,8 +100,8 @@ importers:
         specifier: ^0.34.5
         version: 0.34.5
       vite:
-        specifier: ^7.3.2
-        version: 7.3.2(@types/node@24.10.1)(lightningcss@1.30.2)(sass@1.99.0)(yaml@2.8.2)
+        specifier: ^8.0.10
+        version: 8.0.10(@types/node@24.10.1)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.8.2)
       vitest:
         specifier: ^4.0.15
         version: 4.0.15(@types/node@24.10.1)(lightningcss@1.30.2)(sass@1.99.0)(yaml@2.8.2)
@@ -483,8 +480,17 @@ packages:
     resolution: {integrity: sha512-nt88P6m20AaVbqMxsyPf8KqyWPaFEW2UANi0ijBxc2xTkD2KiUovxfZUYW6NMU9XBYZlovT5LztkEhst2yBcSA==}
     engines: {node: '>=20'}
 
+  '@emnapi/core@1.10.0':
+    resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
+
+  '@emnapi/runtime@1.10.0':
+    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
+
   '@emnapi/runtime@1.7.1':
     resolution: {integrity: sha512-PVtJr5CmLwYAU9PZDMITZoR5iAOShYREoR45EyyLrbntV50mdePTgUn4AmOw90Ifcj+x2kRjdzr1HP3RrNiHGA==}
+
+  '@emnapi/wasi-threads@1.2.1':
+    resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
   '@esbuild/aix-ppc64@0.27.7':
     resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
@@ -811,15 +817,11 @@ packages:
   '@mdx-js/mdx@3.1.1':
     resolution: {integrity: sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ==}
 
-  '@monaco-editor/loader@1.7.0':
-    resolution: {integrity: sha512-gIwR1HrJrrx+vfyOhYmCZ0/JcWqG5kbfG7+d3f/C1LXk2EvzAbHSg3MQ5lO2sMlo9izoAZ04shohfKLVT6crVA==}
-
-  '@monaco-editor/react@4.7.0':
-    resolution: {integrity: sha512-cyzXQCtO47ydzxpQtCGSQGOC8Gk3ZUeBXFAxD+CWXYFo5OqZyZUonFl0DwUlTyAfRHntBfw2p3w4s9R6oe1eCA==}
+  '@napi-rs/wasm-runtime@1.1.4':
+    resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
     peerDependencies:
-      monaco-editor: '>= 0.25.0 < 1'
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
 
   '@nodable/entities@2.1.0':
     resolution: {integrity: sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==}
@@ -838,6 +840,9 @@ packages:
 
   '@oslojs/encoding@1.1.0':
     resolution: {integrity: sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==}
+
+  '@oxc-project/types@0.127.0':
+    resolution: {integrity: sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==}
 
   '@pagefind/darwin-arm64@1.4.0':
     resolution: {integrity: sha512-2vMqkbv3lbx1Awea90gTaBsvpzgRs7MuSgKDxW0m9oV1GPZCZbZBJg/qL83GIUEN2BFlY46dtUZi54pwH+/pTQ==}
@@ -992,6 +997,98 @@ packages:
     resolution: {integrity: sha512-n6oQX6mYkG8TRPuPXmbPidkUbsSRalhmaaVAQxvH1IkQy63cwsH+kOjB3e4cpCDHg0aSvsiX9bQ4s2VB6mGWUQ==}
     engines: {node: '>=18'}
     hasBin: true
+
+  '@rolldown/binding-android-arm64@1.0.0-rc.17':
+    resolution: {integrity: sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.17':
+    resolution: {integrity: sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.0.0-rc.17':
+    resolution: {integrity: sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.17':
+    resolution: {integrity: sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.17':
+    resolution: {integrity: sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.17':
+    resolution: {integrity: sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17':
+    resolution: {integrity: sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17':
+    resolution: {integrity: sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17':
+    resolution: {integrity: sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
+    resolution: {integrity: sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.17':
+    resolution: {integrity: sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
+    resolution: {integrity: sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.17':
+    resolution: {integrity: sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.17':
+    resolution: {integrity: sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.17':
+    resolution: {integrity: sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/pluginutils@1.0.0-rc.17':
+    resolution: {integrity: sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==}
 
   '@rollup/pluginutils@4.2.1':
     resolution: {integrity: sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==}
@@ -1167,6 +1264,9 @@ packages:
 
   '@tootallnate/quickjs-emscripten@0.23.0':
     resolution: {integrity: sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==}
+
+  '@tybys/wasm-util@0.10.1':
+    resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
@@ -2233,8 +2333,20 @@ packages:
     cpu: [arm64]
     os: [android]
 
+  lightningcss-android-arm64@1.32.0:
+    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
   lightningcss-darwin-arm64@1.30.2:
     resolution: {integrity: sha512-ylTcDJBN3Hp21TdhRT5zBOIi73P6/W0qwvlFEk22fkdXchtNTOU4Qc37SkzV+EKYxLouZ6M4LG9NfZ1qkhhBWA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-arm64@1.32.0:
+    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [darwin]
@@ -2245,8 +2357,20 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  lightningcss-darwin-x64@1.32.0:
+    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
   lightningcss-freebsd-x64@1.30.2:
     resolution: {integrity: sha512-c2bH6xTrf4BDpK8MoGG4Bd6zAMZDAXS569UxCAGcA7IKbHNMlhGQ89eRmvpIUGfKWNVdbhSbkQaWhEoMGmGslA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-freebsd-x64@1.32.0:
+    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [freebsd]
@@ -2257,8 +2381,20 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
   lightningcss-linux-arm64-gnu@1.30.2:
     resolution: {integrity: sha512-UK65WJAbwIJbiBFXpxrbTNArtfuznvxAJw4Q2ZGlU8kPeDIWEX1dg3rn2veBVUylA2Ezg89ktszWbaQnxD/e3A==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
@@ -2269,8 +2405,20 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  lightningcss-linux-arm64-musl@1.32.0:
+    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
   lightningcss-linux-x64-gnu@1.30.2:
     resolution: {integrity: sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
@@ -2281,8 +2429,20 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  lightningcss-linux-x64-musl@1.32.0:
+    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
   lightningcss-win32-arm64-msvc@1.30.2:
     resolution: {integrity: sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [win32]
@@ -2293,8 +2453,18 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  lightningcss-win32-x64-msvc@1.32.0:
+    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
   lightningcss@1.30.2:
     resolution: {integrity: sha512-utfs7Pr5uJyyvDETitgsaqSyjCb2qNRAtuqUeWIAKztsOYdcACf2KtARYXg2pSvhkt+9NfoaNY7fxjl6nuMjIQ==}
+    engines: {node: '>= 12.0.0'}
+
+  lightningcss@1.32.0:
+    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
 
   lines-and-columns@1.2.4:
@@ -2595,8 +2765,8 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
-  nanoid@5.1.6:
-    resolution: {integrity: sha512-c7+7RQ+dMB5dPwwCp4ee1/iV/q2P6aK1mTZcfr1BTuVlyW9hJYiMPybJCcnBlQtuSmTIWNeazm/zqNoZSSElBg==}
+  nanoid@5.1.9:
+    resolution: {integrity: sha512-ZUvP7KeBLe3OZ1ypw6dI/TzYJuvHP77IM4Ry73waSQTLn8/g8rpdjfyVAh7t1/+FjBtG4lCP42MEbDxOsRpBMw==}
     engines: {node: ^18 || >=20}
     hasBin: true
 
@@ -2785,6 +2955,10 @@ packages:
   pkg-types@2.3.0:
     resolution: {integrity: sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==}
 
+  postcss@8.5.12:
+    resolution: {integrity: sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==}
+    engines: {node: ^10 || ^12 || >=14}
+
   postcss@8.5.8:
     resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
     engines: {node: ^10 || ^12 || >=14}
@@ -2794,8 +2968,8 @@ packages:
     peerDependencies:
       preact: '>=10 || >= 11.0.0-0'
 
-  preact@11.0.0-beta.0:
-    resolution: {integrity: sha512-IcODoASASYwJ9kxz7+MJeiJhvLriwSb4y4mHIyxdgaRZp6kPUud7xytrk/6GZw8U3y6EFJaRb5wi9SrEK+8+lg==}
+  preact@10.29.1:
+    resolution: {integrity: sha512-gQCLc/vWroE8lIpleXtdJhTFDogTdZG9AjMUpVkDf2iTCNwYNWA+u16dL41TqUDJO4gm2IgrcMv3uTpjd4Pwmg==}
 
   prettier-plugin-astro@0.14.1:
     resolution: {integrity: sha512-RiBETaaP9veVstE4vUwSIcdATj6dKmXljouXc/DDNwBSPTp8FRkLGDSGFClKsAFeeg+13SB0Z1JZvbD76bigJw==}
@@ -2848,15 +3022,6 @@ packages:
   range-parser@1.2.1:
     resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
     engines: {node: '>= 0.6'}
-
-  react-dom@19.2.0:
-    resolution: {integrity: sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==}
-    peerDependencies:
-      react: ^19.2.0
-
-  react@19.2.0:
-    resolution: {integrity: sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==}
-    engines: {node: '>=0.10.0'}
 
   readdirp@3.6.0:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
@@ -2979,6 +3144,11 @@ packages:
   rfdc@1.4.1:
     resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
 
+  rolldown@1.0.0-rc.17:
+    resolution: {integrity: sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
   rollup@4.60.1:
     resolution: {integrity: sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
@@ -3008,9 +3178,6 @@ packages:
   sax@1.6.0:
     resolution: {integrity: sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==}
     engines: {node: '>=11.0.0'}
-
-  scheduler@0.27.0:
-    resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
 
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
@@ -3111,9 +3278,6 @@ packages:
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
-
-  state-local@1.0.7:
-    resolution: {integrity: sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w==}
 
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
@@ -3453,6 +3617,49 @@ packages:
       yaml:
         optional: true
 
+  vite@8.0.10:
+    resolution: {integrity: sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.1.0
+      esbuild: ^0.27.0 || ^0.28.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
   vitefu@1.1.3:
     resolution: {integrity: sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg==}
     peerDependencies:
@@ -3687,14 +3894,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@astrojs/preact@5.1.2(@babel/core@7.28.5)(@types/node@24.10.1)(lightningcss@1.30.2)(preact@11.0.0-beta.0)(rollup@4.60.1)(sass@1.99.0)(yaml@2.8.2)':
+  '@astrojs/preact@5.1.2(@babel/core@7.28.5)(@types/node@24.10.1)(lightningcss@1.30.2)(preact@10.29.1)(rollup@4.60.1)(sass@1.99.0)(yaml@2.8.2)':
     dependencies:
       '@astrojs/internal-helpers': 0.9.0
-      '@preact/preset-vite': 2.10.5(@babel/core@7.28.5)(preact@11.0.0-beta.0)(rollup@4.60.1)(vite@7.3.2(@types/node@24.10.1)(lightningcss@1.30.2)(sass@1.99.0)(yaml@2.8.2))
-      '@preact/signals': 2.9.0(preact@11.0.0-beta.0)
+      '@preact/preset-vite': 2.10.5(@babel/core@7.28.5)(preact@10.29.1)(rollup@4.60.1)(vite@7.3.2(@types/node@24.10.1)(lightningcss@1.30.2)(sass@1.99.0)(yaml@2.8.2))
+      '@preact/signals': 2.9.0(preact@10.29.1)
       devalue: 5.7.1
-      preact: 11.0.0-beta.0
-      preact-render-to-string: 6.6.7(preact@11.0.0-beta.0)
+      preact: 10.29.1
+      preact-render-to-string: 6.6.7(preact@10.29.1)
       vite: 7.3.2(@types/node@24.10.1)(lightningcss@1.30.2)(sass@1.99.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - '@babel/core'
@@ -4096,7 +4303,23 @@ snapshots:
 
   '@cspell/url@9.4.0': {}
 
+  '@emnapi/core@1.10.0':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.1
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.10.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   '@emnapi/runtime@1.7.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.1':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -4357,16 +4580,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@monaco-editor/loader@1.7.0':
+  '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
-      state-local: 1.0.7
-
-  '@monaco-editor/react@4.7.0(monaco-editor@0.55.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
-    dependencies:
-      '@monaco-editor/loader': 1.7.0
-      monaco-editor: 0.55.1
-      react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@tybys/wasm-util': 0.10.1
+    optional: true
 
   '@nodable/entities@2.1.0': {}
 
@@ -4383,6 +4602,8 @@ snapshots:
       fastq: 1.20.1
 
   '@oslojs/encoding@1.1.0': {}
+
+  '@oxc-project/types@0.127.0': {}
 
   '@pagefind/darwin-arm64@1.4.0':
     optional: true
@@ -4467,12 +4688,12 @@ snapshots:
 
   '@polka/url@1.0.0-next.29': {}
 
-  '@preact/preset-vite@2.10.5(@babel/core@7.28.5)(preact@11.0.0-beta.0)(rollup@4.60.1)(vite@7.3.2(@types/node@24.10.1)(lightningcss@1.30.2)(sass@1.99.0)(yaml@2.8.2))':
+  '@preact/preset-vite@2.10.5(@babel/core@7.28.5)(preact@10.29.1)(rollup@4.60.1)(vite@7.3.2(@types/node@24.10.1)(lightningcss@1.30.2)(sass@1.99.0)(yaml@2.8.2))':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/plugin-transform-react-jsx': 7.27.1(@babel/core@7.28.5)
       '@babel/plugin-transform-react-jsx-development': 7.27.1(@babel/core@7.28.5)
-      '@prefresh/vite': 2.4.11(preact@11.0.0-beta.0)(vite@7.3.2(@types/node@24.10.1)(lightningcss@1.30.2)(sass@1.99.0)(yaml@2.8.2))
+      '@prefresh/vite': 2.4.11(preact@10.29.1)(vite@7.3.2(@types/node@24.10.1)(lightningcss@1.30.2)(sass@1.99.0)(yaml@2.8.2))
       '@rollup/pluginutils': 5.3.0(rollup@4.60.1)
       babel-plugin-transform-hook-names: 1.0.2(@babel/core@7.28.5)
       debug: 4.4.3
@@ -4488,27 +4709,27 @@ snapshots:
 
   '@preact/signals-core@1.14.1': {}
 
-  '@preact/signals@2.9.0(preact@11.0.0-beta.0)':
+  '@preact/signals@2.9.0(preact@10.29.1)':
     dependencies:
       '@preact/signals-core': 1.14.1
-      preact: 11.0.0-beta.0
+      preact: 10.29.1
 
   '@prefresh/babel-plugin@0.5.2': {}
 
-  '@prefresh/core@1.5.9(preact@11.0.0-beta.0)':
+  '@prefresh/core@1.5.9(preact@10.29.1)':
     dependencies:
-      preact: 11.0.0-beta.0
+      preact: 10.29.1
 
   '@prefresh/utils@1.2.1': {}
 
-  '@prefresh/vite@2.4.11(preact@11.0.0-beta.0)(vite@7.3.2(@types/node@24.10.1)(lightningcss@1.30.2)(sass@1.99.0)(yaml@2.8.2))':
+  '@prefresh/vite@2.4.11(preact@10.29.1)(vite@7.3.2(@types/node@24.10.1)(lightningcss@1.30.2)(sass@1.99.0)(yaml@2.8.2))':
     dependencies:
       '@babel/core': 7.28.5
       '@prefresh/babel-plugin': 0.5.2
-      '@prefresh/core': 1.5.9(preact@11.0.0-beta.0)
+      '@prefresh/core': 1.5.9(preact@10.29.1)
       '@prefresh/utils': 1.2.1
       '@rollup/pluginutils': 4.2.1
-      preact: 11.0.0-beta.0
+      preact: 10.29.1
       vite: 7.3.2(@types/node@24.10.1)(lightningcss@1.30.2)(sass@1.99.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - supports-color
@@ -4527,6 +4748,57 @@ snapshots:
       - bare-buffer
       - react-native-b4a
       - supports-color
+
+  '@rolldown/binding-android-arm64@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.17':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.0-rc.17': {}
 
   '@rollup/pluginutils@4.2.1':
     dependencies:
@@ -4659,6 +4931,11 @@ snapshots:
   '@standard-schema/spec@1.0.0': {}
 
   '@tootallnate/quickjs-emscripten@0.23.0': {}
+
+  '@tybys/wasm-util@0.10.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
 
   '@types/chai@5.2.3':
     dependencies:
@@ -5919,34 +6196,67 @@ snapshots:
   lightningcss-android-arm64@1.30.2:
     optional: true
 
+  lightningcss-android-arm64@1.32.0:
+    optional: true
+
   lightningcss-darwin-arm64@1.30.2:
+    optional: true
+
+  lightningcss-darwin-arm64@1.32.0:
     optional: true
 
   lightningcss-darwin-x64@1.30.2:
     optional: true
 
+  lightningcss-darwin-x64@1.32.0:
+    optional: true
+
   lightningcss-freebsd-x64@1.30.2:
+    optional: true
+
+  lightningcss-freebsd-x64@1.32.0:
     optional: true
 
   lightningcss-linux-arm-gnueabihf@1.30.2:
     optional: true
 
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    optional: true
+
   lightningcss-linux-arm64-gnu@1.30.2:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.32.0:
     optional: true
 
   lightningcss-linux-arm64-musl@1.30.2:
     optional: true
 
+  lightningcss-linux-arm64-musl@1.32.0:
+    optional: true
+
   lightningcss-linux-x64-gnu@1.30.2:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.32.0:
     optional: true
 
   lightningcss-linux-x64-musl@1.30.2:
     optional: true
 
+  lightningcss-linux-x64-musl@1.32.0:
+    optional: true
+
   lightningcss-win32-arm64-msvc@1.30.2:
     optional: true
 
+  lightningcss-win32-arm64-msvc@1.32.0:
+    optional: true
+
   lightningcss-win32-x64-msvc@1.30.2:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.32.0:
     optional: true
 
   lightningcss@1.30.2:
@@ -5964,6 +6274,22 @@ snapshots:
       lightningcss-linux-x64-musl: 1.30.2
       lightningcss-win32-arm64-msvc: 1.30.2
       lightningcss-win32-x64-msvc: 1.30.2
+
+  lightningcss@1.32.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.32.0
+      lightningcss-darwin-arm64: 1.32.0
+      lightningcss-darwin-x64: 1.32.0
+      lightningcss-freebsd-x64: 1.32.0
+      lightningcss-linux-arm-gnueabihf: 1.32.0
+      lightningcss-linux-arm64-gnu: 1.32.0
+      lightningcss-linux-arm64-musl: 1.32.0
+      lightningcss-linux-x64-gnu: 1.32.0
+      lightningcss-linux-x64-musl: 1.32.0
+      lightningcss-win32-arm64-msvc: 1.32.0
+      lightningcss-win32-x64-msvc: 1.32.0
 
   lines-and-columns@1.2.4: {}
 
@@ -6562,7 +6888,7 @@ snapshots:
 
   nanoid@3.3.11: {}
 
-  nanoid@5.1.6: {}
+  nanoid@5.1.9: {}
 
   neotraverse@0.6.18: {}
 
@@ -6765,17 +7091,23 @@ snapshots:
       exsolve: 1.0.8
       pathe: 2.0.3
 
+  postcss@8.5.12:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
   postcss@8.5.8:
     dependencies:
       nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
-  preact-render-to-string@6.6.7(preact@11.0.0-beta.0):
+  preact-render-to-string@6.6.7(preact@10.29.1):
     dependencies:
-      preact: 11.0.0-beta.0
+      preact: 10.29.1
 
-  preact@11.0.0-beta.0: {}
+  preact@10.29.1: {}
 
   prettier-plugin-astro@0.14.1:
     dependencies:
@@ -6852,13 +7184,6 @@ snapshots:
   radix3@1.1.2: {}
 
   range-parser@1.2.1: {}
-
-  react-dom@19.2.0(react@19.2.0):
-    dependencies:
-      react: 19.2.0
-      scheduler: 0.27.0
-
-  react@19.2.0: {}
 
   readdirp@3.6.0:
     dependencies:
@@ -7073,6 +7398,27 @@ snapshots:
 
   rfdc@1.4.1: {}
 
+  rolldown@1.0.0-rc.17:
+    dependencies:
+      '@oxc-project/types': 0.127.0
+      '@rolldown/pluginutils': 1.0.0-rc.17
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.0.0-rc.17
+      '@rolldown/binding-darwin-arm64': 1.0.0-rc.17
+      '@rolldown/binding-darwin-x64': 1.0.0-rc.17
+      '@rolldown/binding-freebsd-x64': 1.0.0-rc.17
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.17
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.17
+      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.17
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.17
+      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.17
+      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.17
+      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.17
+      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.17
+      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.17
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.17
+      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.17
+
   rollup@4.60.1:
     dependencies:
       '@types/estree': 1.0.8
@@ -7129,8 +7475,6 @@ snapshots:
       '@parcel/watcher': 2.5.6
 
   sax@1.6.0: {}
-
-  scheduler@0.27.0: {}
 
   semver@6.3.1: {}
 
@@ -7266,8 +7610,6 @@ snapshots:
   stack-trace@1.0.0-pre2: {}
 
   stackback@0.0.2: {}
-
-  state-local@1.0.7: {}
 
   statuses@2.0.2: {}
 
@@ -7580,6 +7922,20 @@ snapshots:
       '@types/node': 24.10.1
       fsevents: 2.3.3
       lightningcss: 1.30.2
+      sass: 1.99.0
+      yaml: 2.8.2
+
+  vite@8.0.10(@types/node@24.10.1)(esbuild@0.27.7)(sass@1.99.0)(yaml@2.8.2):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.12
+      rolldown: 1.0.0-rc.17
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      '@types/node': 24.10.1
+      esbuild: 0.27.7
+      fsevents: 2.3.3
       sass: 1.99.0
       yaml: 2.8.2
 

--- a/www/astro.config.mjs
+++ b/www/astro.config.mjs
@@ -45,5 +45,8 @@ export default defineConfig({
     css: {
       transformer: 'lightningcss',
     },
+    resolve: {
+      noExternal: ['monaco-editor'],
+    },
   },
 });

--- a/www/package.json
+++ b/www/package.json
@@ -19,11 +19,10 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@monaco-editor/react": "^4.7.0",
     "fast-deep-equal": "^3.1.3",
     "monaco-editor": "^0.55.1",
-    "nanoid": "^5.1.6",
-    "preact": "11.0.0-beta.0"
+    "nanoid": "^5.1.9",
+    "preact": "10.29.1"
   },
   "devDependencies": {
     "@astrojs/mdx": "^5.0.4",
@@ -41,7 +40,7 @@
     "remark-directive": "^4.0.0",
     "sass": "^1.99.0",
     "sharp": "^0.34.5",
-    "vite": "^7.3.2",
+    "vite": "^8.0.10",
     "vitest": "^4.0.15",
     "zod": "^4.1.13"
   }

--- a/www/src/components/TokenPlayground/components/editor.module.css
+++ b/www/src/components/TokenPlayground/components/editor.module.css
@@ -1,0 +1,4 @@
+.editor {
+  width: 100%;
+  height: 100%;
+}

--- a/www/src/components/TokenPlayground/components/editor.tsx
+++ b/www/src/components/TokenPlayground/components/editor.tsx
@@ -1,51 +1,70 @@
-import {
-  type EditorProps,
-  loader,
-  Editor as MonacoEditor,
-} from '@monaco-editor/react';
+import { editor as monacoEditor } from 'monaco-editor';
+import { useEffect, useLayoutEffect, useRef, useState } from 'preact/hooks';
 import editorWorker from 'monaco-editor/esm/vs/editor/editor.worker?worker';
 import jsonWorker from 'monaco-editor/esm/vs/language/json/json.worker?worker';
-import { useEffect, useMemo, useState } from 'preact/hooks';
 import { DEFAULT_MONACO_OPTIONS } from '../lib/monaco';
+import s from './editor.module.css';
 
-globalThis.MonacoEnvironment = {
-  getWorker(_, label) {
-    switch (label) {
-      case 'json': {
-        return new jsonWorker();
-      }
-      default: {
-        return new editorWorker();
-      }
+self.MonacoEnvironment = {
+  getWorker(_: any, label: string) {
+    if (label === 'json') {
+      return new jsonWorker();
     }
+
+    // To add other langs, see:
+    // https://github.com/microsoft/monaco-editor/blob/main/samples/browser-esm-vite-react/src/userWorker.ts
+
+    return new editorWorker();
   },
 };
 
-/** Hook that loads Monaco and reports on status */
-export function useEditor() {
-  const [loaded, setLoaded] = useState(false);
-  useEffect(() => {
-    // import monaco only after page load
-    (async () => {
-      const monaco = await import('monaco-editor');
-      loader.config({ monaco });
-      loader.init();
-      setLoaded(true);
-    })();
-  }, []);
-  return useMemo(() => ({ loaded }), [loaded]);
+export interface EditorProps {
+  path: string;
+  options?: monacoEditor.IStandaloneEditorConstructionOptions;
+  defaultValue?: string;
+  onChange?: (
+    changes: monacoEditor.IModelContentChangedEvent,
+    contents: string,
+  ) => void;
 }
 
-export default function Editor({ options, ...props }: EditorProps) {
-  return (
-    <MonacoEditor
-      theme="vs-dark"
-      defaultLanguage="json"
-      {...props}
-      options={{
+export default function Editor({
+  defaultValue,
+  onChange,
+  options,
+}: EditorProps) {
+  const [editor, setEditor] =
+    useState<monacoEditor.IStandaloneCodeEditor | null>(null);
+  const monacoEl = useRef(null);
+
+  // mount: setup
+  const onChangeRef = useRef(onChange);
+  onChangeRef.current = onChange;
+  useLayoutEffect(() => {
+    setEditor((prev) => {
+      if (prev) return prev;
+      const editor = monacoEditor.create(monacoEl.current!, {
         ...DEFAULT_MONACO_OPTIONS,
         ...options,
-      }}
-    />
-  );
+        model: monacoEditor.createModel(defaultValue || '', 'json'),
+      });
+      editor.getModel()?.onDidChangeContent((changes) => {
+        onChangeRef.current?.(changes, editor.getModel()?.getValue() || '');
+      });
+      return editor;
+    });
+    return () => editor?.dispose();
+  }, []);
+
+  // listen for defaultValue changes
+  useEffect(() => {
+    if (!defaultValue || !editor) return;
+
+    editor.setModel(monacoEditor.createModel(defaultValue, 'json'));
+    editor.getModel()?.onDidChangeContent((changes) => {
+      onChangeRef.current?.(changes, editor.getModel()?.getValue() || '');
+    });
+  }, [editor, defaultValue]);
+
+  return <div class={s.editor} ref={monacoEl} />;
 }

--- a/www/src/components/TokenPlayground/components/resolver-result.module.css
+++ b/www/src/components/TokenPlayground/components/resolver-result.module.css
@@ -5,6 +5,11 @@
   height: 100%;
 }
 
+.editor {
+  height: 100%;
+  width: 100%;
+}
+
 .modifiers {
   border: none;
   align-items: center;
@@ -32,9 +37,4 @@
 .final {
   display: flex;
   flex: 1 0 auto;
-
-  > * {
-    height: 100%;
-    width: 100%;
-  }
 }

--- a/www/src/components/TokenPlayground/components/resolver-result.tsx
+++ b/www/src/components/TokenPlayground/components/resolver-result.tsx
@@ -1,6 +1,14 @@
-import { DiffEditor } from '@monaco-editor/react';
+import { editor as monacoEditor } from 'monaco-editor';
 import eq from 'fast-deep-equal';
-import { type Dispatch, type StateUpdater, useMemo } from 'preact/hooks';
+import {
+  type Dispatch,
+  type StateUpdater,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'preact/hooks';
 import { DEFAULT_MONACO_OPTIONS } from '../lib/monaco.js';
 import type { Modifier, ResolverImpl } from '../lib/types.js';
 import { diffTokens, flatten, prettyJSON } from '../lib/utils.js';
@@ -22,6 +30,27 @@ export default function ResolverResult({
   defaultInput,
   setInput,
 }: ResolverResultProps) {
+  const [diffEditor, setDiffEditor] = useState<monacoEditor.IDiffEditor | null>(
+    null,
+  );
+  const monacoEl = useRef(null);
+
+  // mount: setup
+  useLayoutEffect(() => {
+    setDiffEditor((prev) => {
+      if (prev) return prev;
+      return monacoEditor.createDiffEditor(monacoEl.current!, {
+        ...DEFAULT_MONACO_OPTIONS,
+        originalEditable: false,
+        readOnly: true,
+        renderGutterMenu: false,
+        renderSideBySide: false,
+      });
+    });
+    return () => diffEditor?.dispose();
+  }, [monacoEl.current]);
+
+  // generate diff based on input, and if user has modified any code
   const finalTokens = useMemo(() => {
     if (!Object.keys(input).length) {
       return { original: '', modified: '' };
@@ -36,6 +65,15 @@ export default function ResolverResult({
     }
     return diffTokens(prettyJSON(actual), modified);
   }, [resolver, input]);
+
+  // update diff
+  useEffect(() => {
+    if (!diffEditor) return;
+    diffEditor.setModel({
+      original: monacoEditor.createModel(finalTokens.original, 'json'),
+      modified: monacoEditor.createModel(finalTokens.modified, 'json'),
+    });
+  }, [diffEditor, finalTokens]);
 
   return (
     <div class={s.container}>
@@ -59,17 +97,7 @@ export default function ResolverResult({
       </div>
 
       <section class={s.final}>
-        <DiffEditor
-          theme="vs-dark"
-          options={{
-            ...DEFAULT_MONACO_OPTIONS,
-            renderGutterMenu: false,
-            renderSideBySide: false,
-          }}
-          keepCurrentOriginalModel={false}
-          original={finalTokens.original}
-          modified={finalTokens.modified}
-        />
+        <div class={s.editor} ref={monacoEl} />
       </section>
     </div>
   );

--- a/www/src/components/TokenPlayground/index.tsx
+++ b/www/src/components/TokenPlayground/index.tsx
@@ -4,7 +4,7 @@ import { ZodError } from 'zod/v4';
 import Nav from './components/nav.js';
 import { createResolver } from './lib/create-resolver.js';
 import type { Modifier, Preset, Resolver, ResolverImpl } from './lib/types.js';
-import Editor, { useEditor } from './components/editor.js';
+import Editor from './components/editor.js';
 import ResolverResult from './components/resolver-result.js';
 import { prettyJSON } from './lib/utils.js';
 import s from './index.module.css';
@@ -115,8 +115,6 @@ export default function TokenPlayground() {
     }
   }, [files, errors, preset]);
 
-  const { loaded } = useEditor();
-
   if (!Object.keys(files).length) {
     return (
       <div role="status" class={s.loading}>
@@ -141,38 +139,36 @@ export default function TokenPlayground() {
         {errors[currentFile] ? (
           <div class={s.editorError}>{errors[currentFile]}</div>
         ) : null}
-        {loaded && (
-          <Editor
-            path={
-              `${preset}/${currentFile}` // prefixing with preset prevents conflicts between files like resolver.json
+        <Editor
+          path={
+            `${preset}/${currentFile}` // prefixing with preset prevents conflicts between files like resolver.json
+          }
+          defaultValue={files[currentFile]}
+          onChange={(_changes, contents) => {
+            try {
+              setErrors((value) => ({ ...value, [currentFile]: undefined }));
+              const tryResolver = resolverFromFiles({
+                ...files,
+                [currentFile]: JSON.parse(contents),
+              });
+              tryResolver.apply(input); // TODO: improve resolver to be able to throw errors earlier
+              setFiles((value) => ({ ...value, [currentFile]: contents }));
+            } catch (err) {
+              console.error(err);
+              const message =
+                err instanceof ZodError &&
+                Array.isArray(JSON.parse(err.message))
+                  ? JSON.parse(err.message)
+                      .map((e) => e.message)
+                      .join('\n')
+                  : String(err);
+              setErrors((value) => ({ ...value, [currentFile]: message }));
             }
-            defaultValue={files[currentFile]}
-            onChange={(contents) => {
-              try {
-                setErrors((value) => ({ ...value, [currentFile]: undefined }));
-                const tryResolver = resolverFromFiles({
-                  ...files,
-                  [currentFile]: JSON.parse(contents),
-                });
-                tryResolver.apply(input); // TODO: improve resolver to be able to throw errors earlier
-                setFiles((value) => ({ ...value, [currentFile]: contents }));
-              } catch (err) {
-                console.error(err);
-                const message =
-                  err instanceof ZodError &&
-                  Array.isArray(JSON.parse(err.message))
-                    ? JSON.parse(err.message)
-                        .map((e) => e.message)
-                        .join('\n')
-                    : String(err);
-                setErrors((value) => ({ ...value, [currentFile]: message }));
-              }
-            }}
-          />
-        )}
+          }}
+        />
       </div>
       <div class={s.resolverResult}>
-        {loaded && resolver && (
+        {resolver && (
           <ResolverResult
             resolver={resolver}
             modifiers={modifiers}

--- a/www/src/components/TokenPlayground/lib/monaco.ts
+++ b/www/src/components/TokenPlayground/lib/monaco.ts
@@ -2,6 +2,7 @@ import type * as monaco from 'monaco-editor';
 
 export const DEFAULT_MONACO_OPTIONS: monaco.editor.IStandaloneEditorConstructionOptions =
   {
+    theme: 'vs-dark',
     detectIndentation: true,
     fontFamily: 'Fragment Mono',
     fontSize: 11,

--- a/www/src/pages/playground.astro
+++ b/www/src/pages/playground.astro
@@ -4,5 +4,5 @@ import TokenPlayground from '@/components/TokenPlayground/index.js';
 ---
 
 <Blank title="DTCG Playground" footer={false}>
-  <TokenPlayground client:load />
+  <TokenPlayground client:only="preact" />
 </Blank>


### PR DESCRIPTION

## Changes

The `@monaco-editor/react` package is not associated with the `monaco-editor` library, and broke when Vite or Astro updated. This PR replaces it with more manual monaco editor usage.

**Before**

<img width="2822" height="1764" alt="CleanShot 2026-04-26 at 20 14 47@2x" src="https://github.com/user-attachments/assets/8693bc63-41eb-469e-9221-6fdb35aa4ea6" />


**After**

<img width="2826" height="1760" alt="CleanShot 2026-04-26 at 20 14 30@2x" src="https://github.com/user-attachments/assets/2fe5342c-bf14-4475-bcea-7285ff38d4bd" />


## How to Review

- See Netlify link, visit `/playground`
