### PR TITLE
docs: add Penpot to UI design tool lists

### DIFF
--- a/technical-reports/format/terminology.md
+++ b/technical-reports/format/terminology.md
@@ -43,6 +43,7 @@ For example:
   - [UXPin](https://www.uxpin.com/)
   - [Sketch](https://www.sketch.com/)
   - [Figma](https://www.figma.com/)
+  - [Penpot](https://penpot.app/)
   - ...
 
 ## <dfn>Translation tool</dfn>

--- a/www/src/pages/glossary.md
+++ b/www/src/pages/glossary.md
@@ -89,6 +89,7 @@ A tool for visual design creation and editing.
 - UXPin
 - Sketch
 - Figma
+- Penpot
 - Marvel
 
 ### Documentation tool
@@ -244,4 +245,4 @@ Generic term describing the most common way (but not the only way) a design toke
 
 ### Vendor
 
-Company shipping design tool(s), in a position to implement the design token specification, such as Adobe, Framer, UXPin, Figma, Sketch, and many others.
+Company shipping design tool(s), in a position to implement the design token specification, such as Adobe, Framer, UXPin, Figma, Penpot, Sketch, and many others.


### PR DESCRIPTION
## Summary

- Adds [Penpot](https://penpot.app/) to the **UI design, wireframing and prototyping tools** example list in `technical-reports/format/terminology.md`
- Adds Penpot to the **Design tool** examples list in `www/src/pages/glossary.md`
- Adds Penpot to the **Vendor** definition prose in `www/src/pages/glossary.md`

Penpot is an open-source, web-based UI design and prototyping tool that already ships DTCG-compatible token support (it is listed in the adopters grid on the homepage). Omitting it from the terminology and glossary examples creates an inconsistency with the rest of the site.

Note: `faq.md` and `www/src/pages/index.astro` already list Penpot and were not changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)