### PR TITLE
fix: correct resolver draft version field type from YYYY-MM-DD to YYYY.MM

### DIFF
--- a/technical-reports/resolver/syntax.md
+++ b/technical-reports/resolver/syntax.md
@@ -7,7 +7,7 @@ A resolver document contains the following properties at the root level:
 | Name                                     | Type                                     | Required | Description                                                      |
 | :--------------------------------------- | :--------------------------------------- | :------: | :--------------------------------------------------------------- |
 | [**name**](#name)                        | `string`                                 |          | A short, human-readable name for the document.                   |
-| [**version**](#version)                  | `YYYY-MM-DD`                             |    Y     | Version. Must be `2025.10`.                                      |
+| [**version**](#version)                  | `YYYY.MM`                             |    Y     | Version. Must be `2025.10`.                                      |
 | [**description**](#description)          | `string`                                 |          | A human-readable description for this document.                  |
 | [**sets**](#sets)                        | Map[`string`, Set]                       |          | Definition of sets.                                              |
 | [**modifiers**](#modifiers)              | Map[`string, Modifier]                   |          | Definition of modifiers.                                         |

--- a/technical-reports/resolver/syntax.md
+++ b/technical-reports/resolver/syntax.md
@@ -7,7 +7,7 @@ A resolver document contains the following properties at the root level:
 | Name                                     | Type                                     | Required | Description                                                      |
 | :--------------------------------------- | :--------------------------------------- | :------: | :--------------------------------------------------------------- |
 | [**name**](#name)                        | `string`                                 |          | A short, human-readable name for the document.                   |
-| [**version**](#version)                  | `YYYY.MM`                             |    Y     | Version. Must be `2025.10`.                                      |
+| [**version**](#version)                  | `YYYY.MM`                                |    Y     | Version. Must be `2025.10`.                                      |
 | [**description**](#description)          | `string`                                 |          | A human-readable description for this document.                  |
 | [**sets**](#sets)                        | Map[`string`, Set]                       |          | Definition of sets.                                              |
 | [**modifiers**](#modifiers)              | Map[`string, Modifier]                   |          | Definition of modifiers.                                         |


### PR DESCRIPTION
## Summary

- Corrects the `version` field **Type** column in the root-level properties table of \`technical-reports/resolver/syntax.md\` from \`YYYY-MM-DD\` to \`YYYY.MM\`

## Problem

The draft resolver document's root-level properties table lists the \`version\` field type as \`YYYY-MM-DD\` (ISO 8601 date format), while the required literal value in the same cell — and in the §4.1.2 Version prose — remains \`2025.10\`. These two are internally contradictory:

- \`YYYY-MM-DD\` expects a hyphen-separated year-month-day string (e.g. \`2025-10-28\`)
- \`2025.10\` is dot-separated year.month — a valid \`YYYY.MM\` value, but not a valid \`YYYY-MM-DD\` value

The stable Final Community Group Report ([designtokens.org/TR/2025.10/resolver/#root-level-properties](https://www.designtokens.org/TR/2025.10/resolver/#root-level-properties)) correctly lists the type as \`YYYY.MM\`, consistent with the required value \`2025.10\` and the §4.1.2 prose. The draft appears to have introduced \`YYYY-MM-DD\` as an editorial slip — the description and prose were not updated to match.

## Change

\`\`\`diff
- | [**version**](#version) | `YYYY-MM-DD` | Y | Version. Must be `2025.10`. |
+ | [**version**](#version) | `YYYY.MM`    | Y | Version. Must be `2025.10`. |
\`\`\`

No other content is changed. The §4.1.2 prose already says the correct thing and needed no update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)