### PR TITLE
Update Alias glossary example to use 2025.10 color object value

### DIFF
--- a/www/src/pages/glossary.md
+++ b/www/src/pages/glossary.md
@@ -14,7 +14,7 @@ A token value that is a reference to another token.
 
 #### Example
 
-The value of `color.text.primary` is `#000000`, because it references `color.palette.black`:
+The value of `color.text.base` is black, because it references `color.palette.black`:
 
 ```json
 {
@@ -23,12 +23,14 @@ The value of `color.text.primary` is `#000000`, because it references `color.pal
     "palette": {
       "black": {
         "$type": "color",
-        "$value": "#000000"
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [0, 0, 0]
+        }
       }
     },
     "text": {
-      "primary": {
-        "$type": "color",
+      "base": {
         "$value": "{color.palette.black}"
       }
     }

--- a/www/src/pages/glossary.md
+++ b/www/src/pages/glossary.md
@@ -25,7 +25,8 @@ The value of `color.text.base` is black, because it references `color.palette.bl
         "$type": "color",
         "$value": {
           "colorSpace": "srgb",
-          "components": [0, 0, 0]
+          "components": [0, 0, 0],
+          "hex": "#000000"
         }
       }
     },


### PR DESCRIPTION
Replace the deprecated hex string color value with the structured
srgb color object format, and rename color.text.primary to
color.text.base to match.