### PR TITLE
chore(blog): add blog post “Thank you, Jina and Val”

### DIFF
--- a/www/src/content/w3c.json
+++ b/www/src/content/w3c.json
@@ -47,5 +47,12 @@
     "date": "2025-10-28",
     "author": "Kaelig Deloumeau-Prigent",
     "url": "https://www.w3.org/community/design-tokens/2025/10/28/design-tokens-specification-reaches-first-stable-version/"
+  },
+  {
+    "id": "thank-you-jina-and-val",
+    "title": "Thank you, Jina and Val",
+    "date": "2026-06-17",
+    "author": "Kaelig Deloumeau-Prigent",
+    "url": "https://www.w3.org/community/design-tokens/2026/06/17/thank-you-jina-and-val/"
   }
 ]


### PR DESCRIPTION
Adds the latest W3C Design Tokens Community Group blog post to `www/src/content/w3c.json`.

**Post:** Thank you, Jina and Val
**Date:** 2026-06-17
**Author:** Kaelig Deloumeau-Prigent
**URL:** https://www.w3.org/community/design-tokens/2026/06/17/thank-you-jina-and-val/

Source feed: https://www.w3.org/community/design-tokens/feed/

_Opened automatically by the DTCG blog-feed sync task._